### PR TITLE
Quest name current year variable

### DIFF
--- a/src/games/stendhal/server/entity/player/PlayerQuests.java
+++ b/src/games/stendhal/server/entity/player/PlayerQuests.java
@@ -1,6 +1,5 @@
-/* $Id$ */
 /***************************************************************************
- *                   (C) Copyright 2003-2010 - Stendhal                    *
+ *                   (C) Copyright 2003-2015 - Stendhal                    *
  ***************************************************************************
  ***************************************************************************
  *                                                                         *
@@ -12,17 +11,20 @@
  ***************************************************************************/
 package games.stendhal.server.entity.player;
 
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
 import games.stendhal.common.MathHelper;
 import games.stendhal.server.core.engine.GameEvent;
 import games.stendhal.server.core.engine.SingletonRepository;
-
-import java.util.LinkedList;
-import java.util.List;
-
+import games.stendhal.server.util.StringUtils;
 import marauroa.common.game.RPObject;
 import marauroa.common.game.RPSlot;
-
-import org.apache.log4j.Logger;
 
 /**
  * Accesses the player quest states.
@@ -66,7 +68,7 @@ class PlayerQuests {
 	 * @return true iff the player has made any progress in the quest
 	 */
 	public boolean hasQuest(final String name) {
-		return (player.getKeyedSlot("!quests", name) != null);
+		return (player.getKeyedSlot("!quests", evaluateSlotName(name)) != null);
 	}
 
 	/**
@@ -77,7 +79,7 @@ class PlayerQuests {
 	 * @return the player's status in the quest
 	 */
 	public String getQuest(final String name) {
-		return player.getKeyedSlot("!quests", name);
+		return player.getKeyedSlot("!quests", evaluateSlotName(name));
 	}
 
 	/**
@@ -94,10 +96,10 @@ class PlayerQuests {
 	 *            reset the player's status for the quest.
 	 */
 	public void setQuest(final String name, final String status) {
-		final String oldStatus = player.getKeyedSlot("!quests", name);
-		player.setKeyedSlot("!quests", name, status);
+		final String oldStatus = player.getKeyedSlot("!quests", evaluateSlotName(name));
+		player.setKeyedSlot("!quests", evaluateSlotName(name), status);
 		if ((status == null) || !status.equals(oldStatus)) {
-			new GameEvent(player.getName(), "quest", name, status).raise();
+			new GameEvent(player.getName(), "quest", evaluateSlotName(name), status).raise();
 		}
 		// check for reached achievements
 		SingletonRepository.getAchievementNotifier().onFinishQuest(player);
@@ -184,7 +186,7 @@ class PlayerQuests {
 	}
 
 	public void removeQuest(final String name) {
-		player.setKeyedSlot("!quests", name, null);
+		player.setKeyedSlot("!quests", evaluateSlotName(name), null);
 	}
 
 	/**
@@ -295,5 +297,22 @@ class PlayerQuests {
 		}
 		String questState = player.getQuest(name, index);
 		return MathHelper.parseIntDefault(questState, 0);
+	}
+
+	/**
+	 * evaluates slot names by replacing variables
+	 *
+	 * @param name name of slot
+	 * @return evaluated slot
+	 */
+	String evaluateSlotName(String name) {
+		Map<String, String> params = new HashMap<String, String>();
+		Calendar calendar = Calendar.getInstance();
+		int year = calendar.get(Calendar.YEAR);
+		params.put("year", Integer.toString(year).substring(2));
+		calendar.add(Calendar.MONTH, -2);
+		year = calendar.get(Calendar.YEAR);
+		params.put("seasonyear", Integer.toString(year).substring(2));
+		return StringUtils.substitute(name, params);
 	}
 }

--- a/src/games/stendhal/server/maps/quests/EasterGiftsForChildren.java
+++ b/src/games/stendhal/server/maps/quests/EasterGiftsForChildren.java
@@ -69,7 +69,7 @@ import java.util.List;
  */
 public class EasterGiftsForChildren extends AbstractQuest {
 
-	private static final String QUEST_SLOT = "easter_gifts_14";
+	private static final String QUEST_SLOT = "easter_gifts_[year]";
 
 	
 

--- a/src/games/stendhal/server/maps/quests/MeetBunny.java
+++ b/src/games/stendhal/server/maps/quests/MeetBunny.java
@@ -48,7 +48,7 @@ import java.util.List;
  */
 public class MeetBunny extends AbstractQuest {
 	// quest slot changed ready for 2015
-	private static final String QUEST_SLOT = "meet_bunny_15";
+	private static final String QUEST_SLOT = "meet_bunny_[year]";
 
 	/** the Bunny NPC. */
 	protected SpeakerNPC bunny;

--- a/src/games/stendhal/server/maps/quests/MeetSanta.java
+++ b/src/games/stendhal/server/maps/quests/MeetSanta.java
@@ -57,7 +57,7 @@ import games.stendhal.server.entity.player.Player;
 public class MeetSanta extends AbstractQuest implements LoginListener {
 
 	// quest slot changed ready for 2015
-	private static final String QUEST_SLOT = "meet_santa_15";
+	private static final String QUEST_SLOT = "meet_santa_[seasonyear]";
 
 	public static final String QUEST_NAME = "MeetSanta";
 

--- a/src/games/stendhal/server/maps/quests/PaperChase.java
+++ b/src/games/stendhal/server/maps/quests/PaperChase.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * @author hendrik
  */
 public class PaperChase extends AbstractQuest implements TeleportListener {
-	private static final String QUEST_SLOT = "paper_chase_2015";
+	private static final String QUEST_SLOT = "paper_chase_20[year]";
 	private static final String FAME_TYPE = QUEST_SLOT.substring(QUEST_SLOT.length() - 1);
 	
 	private static final int TELEPORT_PENALTY_IN_MINUTES = 10;

--- a/src/games/stendhal/server/maps/quests/revivalweeks/SokobanGame.java
+++ b/src/games/stendhal/server/maps/quests/revivalweeks/SokobanGame.java
@@ -49,7 +49,7 @@ import marauroa.server.db.command.DBCommandQueue;
  * @author hendrik
  */
 public class SokobanGame implements LoadableContent, SokobanListener {
-	private static final String QUEST_SLOT = "sokoban_2015";
+	private static final String QUEST_SLOT = "sokoban_20[year]";
 	private static final String FAME_TYPE = "S";
 	
 	/** start, done */


### PR DESCRIPTION
There is a number of quest which can be repeated every year (such as meet the easter bunny). Currently we have to manually change the quest slot name every quest. This patch automatically picks the current year (or the current seasonyear for christmas)