### PR TITLE
Fix for bug 4987: Quest history StuffForBaldemar - state items still needed

### DIFF
--- a/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
+++ b/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
@@ -12,6 +12,11 @@
  ***************************************************************************/
 package games.stendhal.server.maps.quests;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
 import games.stendhal.common.MathHelper;
 import games.stendhal.common.grammar.Grammar;
 import games.stendhal.common.parser.Sentence;
@@ -29,14 +34,9 @@ import games.stendhal.server.entity.npc.condition.QuestStartedCondition;
 import games.stendhal.server.entity.npc.condition.QuestStateStartsWithCondition;
 import games.stendhal.server.entity.player.Player;
 import games.stendhal.server.maps.Region;
+import games.stendhal.server.maps.quests.logic.ItemCollector;
+import games.stendhal.server.maps.quests.logic.ItemCollectorData;
 import games.stendhal.server.util.TimeUtil;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * QUEST: The mithril shield forging.
@@ -73,167 +73,6 @@ public class StuffForBaldemar extends AbstractQuest {
 
 	static final String TALK_NEED_KILL_GIANT = "This shield can only be given to those who have killed a black giant, and without the help of others.";
 
-	private static Map<Integer, ItemData> neededItems = initNeededItems();
-	private static Map<Integer, ItemData> initNeededItems() {
-		neededItems = new TreeMap<Integer, ItemData>();
-		ItemData data;
-
-		data = new ItemData("mithril bar", REQUIRED_MITHRIL_BAR,
-				"I cannot #forge it without the missing ",
-				". After all, this IS a mithril shield.");
-		neededItems.put(1, data);
-
-		data = new ItemData("obsidian",	REQUIRED_OBSIDIAN,
-				"I need several gems to grind into dust to mix with the mithril. I need ",
-				" still.");
-		neededItems.put(2, data);
-
-		data = new ItemData("diamond", REQUIRED_DIAMOND,
-				"I need several gems to grind into dust to mix with the mithril. I need ",
-				" still.");
-		neededItems.put(3, data);
-		
-		data = new ItemData("emerald", REQUIRED_EMERALD,
-				"I need several gems to grind into dust to mix with the mithril. I need ",
-				" still.");
-		neededItems.put(4, data);
-		
-		data = new ItemData("carbuncle", REQUIRED_CARBUNCLE,
-				"I need several gems to grind into dust to mix with the mithril. I need ",
-				" still.");
-		neededItems.put(5, data);
-		
-		data = new ItemData("sapphire",	REQUIRED_SAPPHIRE,
-				"I need several gems to grind into dust to mix with the mithril. I need ",
-				" still.");
-		neededItems.put(6, data);
-
-		data = new ItemData("black shield",	REQUIRED_BLACK_SHIELD,
-				"I need ",
-				" to form the framework for your new shield.");
-		neededItems.put(7, data);
-		
-		data = new ItemData("magic plate shield", REQUIRED_MAGIC_PLATE_SHIELD,
-				"I need ",
-				" for the pieces and parts for your new shield.");
-		neededItems.put(8, data);
-	
-		data = new ItemData("gold bar",	REQUIRED_GOLD_BAR,
-				"I need ",
-				" to melt down with the mithril and iron.");
-		neededItems.put(9, data);
-
-		data = new ItemData("iron",	REQUIRED_IRON,
-				"I need ",
-				" to melt down with the mithril and gold.");
-		neededItems.put(10, data);
-
-		data = new ItemData("black pearl", REQUIRED_BLACK_PEARL,
-				"I need ",
-				" to crush into fine powder to sprinkle onto shield to give it a nice sheen.");
-		neededItems.put(11, data);
-
-		data = new ItemData("shuriken",	REQUIRED_SHURIKEN,
-				"I need ",
-				" to melt down with the mithril, gold and iron. It is a 'secret' ingredient that only you and I know about. ;)");
-		neededItems.put(12, data);
-
-		data = new ItemData("marbles", REQUIRED_MARBLES,
-				"My son wants some new toys. I need ",
-				" still.");
-		neededItems.put(13, data);
-
-		data = new ItemData("snowglobe", REQUIRED_SNOWGLOBE,
-				"I just LOVE those trinkets from athor. I need ",
-				" still.");
-		neededItems.put(14, data);
-		return neededItems;
-	}
-
-	protected static final class ItemData {
-
-		private int neededAmount;
-		private final String itemName;
-		private final String itemPrefix;
-		private final String itemSuffix;
-		private final int requiredAmount;
-
-		public ItemData(final String name, final int needed, final String prefix, final String suffix) {
-			this.requiredAmount = needed;
-			this.neededAmount = needed;
-			this.itemName = name;
-			this.itemPrefix = prefix;
-			this.itemSuffix = suffix;
-		}
-
-		public int getStillNeeded() {
-			return neededAmount;
-		}
-
-		public void setAmount(final int needed) {
-			neededAmount = needed;
-		}
-
-		public String getName() {
-			return itemName;
-		}
-
-		public void subAmount(final String string) {
-			subAmount(Integer.parseInt(string));
-		}
-
-		public String getAnswer() {
-			return itemPrefix
-				+ Grammar.quantityplnoun(
-						neededAmount, itemName, "a")
-				+ itemSuffix;
-		}
-
-		public int getRequired() {
-			return requiredAmount;
-		}
-
-		public int getAlreadyBrought() {
-			return requiredAmount - neededAmount;
-		}
-
-		public void subAmount(final int amount) {
-			neededAmount -= amount;
-		}
-
-		public void resetAmount() {
-			neededAmount = requiredAmount;
-		}
-	}
-
-	private static final int REQUIRED_MITHRIL_BAR = 20;
-
-	private static final int REQUIRED_OBSIDIAN = 1;
-
-	private static final int REQUIRED_DIAMOND = 1;
-
-	private static final int REQUIRED_EMERALD = 5;
-	
-	private static final int REQUIRED_CARBUNCLE = 10;
-
-	private static final int REQUIRED_SAPPHIRE = 10;
-
-	private static final int REQUIRED_BLACK_SHIELD = 1;
-
-	private static final int REQUIRED_MAGIC_PLATE_SHIELD = 1;
-
-	private static final int REQUIRED_GOLD_BAR = 10;
-
-	private static final int REQUIRED_IRON = 20;
-
-	private static final int REQUIRED_BLACK_PEARL = 10;
-
-	private static final int REQUIRED_SHURIKEN = 20;
-	
-	private static final int REQUIRED_MARBLES = 15;
-
-	private static final int REQUIRED_SNOWGLOBE = 1;
-
 	private static final String I_WILL_NEED_MANY_THINGS = "I will need many, many things: ";
 
 	private static final String IN_EXACT_ORDER = "Come back when you have them in the same #exact order!";
@@ -241,6 +80,35 @@ public class StuffForBaldemar extends AbstractQuest {
 	private static final int REQUIRED_MINUTES = 10;
 
 	private static final String QUEST_SLOT = "mithrilshield_quest";
+
+	private final ItemCollector itemCollector = new ItemCollector();
+
+	public StuffForBaldemar() {
+		itemCollector.require().item("mithril bar").pieces(20)
+				.bySaying("I cannot #forge it without the missing %s. After all, this IS a mithril shield.");
+		itemCollector.require().item("obsidian")
+				.bySaying("I need several gems to grind into dust to mix with the mithril. I need %s still.");
+		itemCollector.require().item("diamond")
+				.bySaying("I need several gems to grind into dust to mix with the mithril. I need %s still.");
+		itemCollector.require().item("emerald").pieces(5)
+				.bySaying("I need several gems to grind into dust to mix with the mithril. I need %s still.");
+		itemCollector.require().item("carbuncle").pieces(10)
+				.bySaying("I need several gems to grind into dust to mix with the mithril. I need %s still.");
+		itemCollector.require().item("sapphire").pieces(10)
+				.bySaying("I need several gems to grind into dust to mix with the mithril. I need %s still.");
+		itemCollector.require().item("black shield").bySaying("I need %s to form the framework for your new shield.");
+		itemCollector.require().item("magic plate shield")
+				.bySaying("I need %s for the pieces and parts for your new shield.");
+		itemCollector.require().item("gold bar").pieces(10)
+				.bySaying("I need %s to melt down with the mithril and iron.");
+		itemCollector.require().item("iron").pieces(20).bySaying("I need %s to melt down with the mithril and gold.");
+		itemCollector.require().item("black pearl").pieces(10)
+				.bySaying("I need %s to crush into fine powder to sprinkle onto shield to give it a nice sheen.");
+		itemCollector.require().item("shuriken").pieces(20).bySaying(
+				"I need %s to melt down with the mithril, gold and iron. It is a 'secret' ingredient that only you and I know about. ;)");
+		itemCollector.require().item("marbles").pieces(15).bySaying("My son wants some new toys. I need %s still.");
+		itemCollector.require().item("snowglobe").bySaying("I just LOVE those trinkets from Athor. I need %s still.");
+	}
 
 	@Override
 	public String getSlotName() {
@@ -310,19 +178,18 @@ public class StuffForBaldemar extends AbstractQuest {
 					final String[] tokens = player.getQuest(QUEST_SLOT).split(";");
 					
 					int idx1 = 1;
-					for (ItemData itemdata : neededItems.values()) {
+					for (ItemCollectorData itemdata: itemCollector.requiredItems()) {
 							itemdata.resetAmount();
-							itemdata.subAmount(tokens[idx1]);
+							itemdata.subtractAmount(tokens[idx1]);
 							idx1++;
 					}
 
 					boolean missingSomething = false;
 
-					int size = neededItems.size();
-					for (int idx = 1; !missingSomething && idx <= size; idx++) {
-						ItemData itemData = neededItems.get(idx);
-						missingSomething = proceedItem(player, raiser,
-								itemData);
+					int size = itemCollector.requiredItems().size();
+					for (int idx = 0; !missingSomething && idx < size; idx++) {
+						ItemCollectorData itemData = itemCollector.requiredItems().get(idx);
+						missingSomething = proceedItem(player, raiser, itemData);
 					}
 					
 					if (player.hasKilledSolo("black giant") && !missingSomething) {
@@ -337,7 +204,7 @@ public class StuffForBaldemar extends AbstractQuest {
 
 						StringBuilder sb = new StringBuilder(30);
 						sb.append("start");
-						for (ItemData id : neededItems.values()) {
+						for (ItemCollectorData id : itemCollector.requiredItems()) {
 							sb.append(";");
 							sb.append(id.getAlreadyBrought());
 						}
@@ -346,17 +213,17 @@ public class StuffForBaldemar extends AbstractQuest {
 				}
 
 				private boolean proceedItem(final Player player,
-						final EventRaiser engine, final ItemData itemData) {
+						final EventRaiser engine, final ItemCollectorData itemData) {
 					if (itemData.getStillNeeded() > 0) {
 						
 						if (player.isEquipped(itemData.getName(), itemData.getStillNeeded())) {
 							player.drop(itemData.getName(), itemData.getStillNeeded());
-							itemData.setAmount(0);
+							itemData.subtractAmount(itemData.getStillNeeded());
 						} else {
 							final int amount = player.getNumberOfEquipped(itemData.getName());
 							if (amount > 0) {
 								player.drop(itemData.getName(), amount);
-								itemData.subAmount(amount);
+								itemData.subtractAmount(amount);
 							}
 
 							engine.say(itemData.getAnswer());
@@ -437,13 +304,13 @@ public class StuffForBaldemar extends AbstractQuest {
 	private List<String> neededItemsWithAmounts(final Player player) {
 		int[] broughtItems = broughtItems(player);
 		List<String> neededItemsWithAmounts = new LinkedList<>();
-		for (int i = 1; i <= neededItems.size(); i++) {
-			ItemData item = neededItems.get(i);
-			int required = item.requiredAmount;
-			int brought = broughtItems[i - 1];
+		for (int i = 0; i < itemCollector.requiredItems().size(); i++) {
+			ItemCollectorData item = itemCollector.requiredItems().get(i);
+			int required = item.getRequiredAmount();
+			int brought = broughtItems[i];
 			int neededAmount = required - brought;
 			if (neededAmount > 0) {
-				neededItemsWithAmounts.add(neededItem(neededAmount, item.itemName));
+				neededItemsWithAmounts.add(neededItem(neededAmount, item.getName()));
 			}
 		}
 
@@ -451,7 +318,7 @@ public class StuffForBaldemar extends AbstractQuest {
 	}
 
 	private int[] broughtItems(final Player player) {
-		int[] brought = new int[neededItems.size()];
+		int[] brought = new int[itemCollector.requiredItems().size()];
 		if (player.getQuest(QUEST_SLOT) != null) {
 			String[] broughtTokens = player.getQuest(QUEST_SLOT).split(";");
 			for (int i = 1; i < broughtTokens.length; i++) {

--- a/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
+++ b/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
@@ -69,86 +69,83 @@ import java.util.TreeMap;
  * </ul>
  */
 public class StuffForBaldemar extends AbstractQuest {
-	private static Map<Integer, ItemData> neededItems = initneededitems();
-	private static Map<Integer, ItemData> initneededitems() {
+	private static Map<Integer, ItemData> neededItems = initNeededItems();
+	private static Map<Integer, ItemData> initNeededItems() {
 		neededItems = new TreeMap<Integer, ItemData>();
-		ItemData data = new ItemData("mithril bar", 
-									REQUIRED_MITHRIL_BAR, 
-									"I cannot #forge it without the missing ", 
-									". After all, this IS a mithril shield.");
+		ItemData data;
+
+		data = new ItemData("mithril bar", REQUIRED_MITHRIL_BAR,
+				"I cannot #forge it without the missing ",
+				". After all, this IS a mithril shield.");
 		neededItems.put(1, data);
-		data = new ItemData("obsidian",	REQUIRED_OBSIDIAN, 
-				"I need several gems to grind into dust to mix with the mithril. I need ", 
+
+		data = new ItemData("obsidian",	REQUIRED_OBSIDIAN,
+				"I need several gems to grind into dust to mix with the mithril. I need ",
 				" still.");
 		neededItems.put(2, data);
-		data = new ItemData("diamond",	REQUIRED_DIAMOND , 
-				"I need several gems to grind into dust to mix with the mithril. I need ", 
+
+		data = new ItemData("diamond", REQUIRED_DIAMOND,
+				"I need several gems to grind into dust to mix with the mithril. I need ",
 				" still.");
 		neededItems.put(3, data);
 		
-		
-		data = new ItemData("emerald",	REQUIRED_EMERALD , 
-				"I need several gems to grind into dust to mix with the mithril. I need ", 
+		data = new ItemData("emerald", REQUIRED_EMERALD,
+				"I need several gems to grind into dust to mix with the mithril. I need ",
 				" still.");
 		neededItems.put(4, data);
 		
-		data = new ItemData("carbuncle",	REQUIRED_CARBUNCLE , 
-				"I need several gems to grind into dust to mix with the mithril. I need ", 
+		data = new ItemData("carbuncle", REQUIRED_CARBUNCLE,
+				"I need several gems to grind into dust to mix with the mithril. I need ",
 				" still.");
 		neededItems.put(5, data);
 		
-		data = new ItemData("sapphire",	REQUIRED_SAPPHIRE, 
-				"I need several gems to grind into dust to mix with the mithril. I need ", 
+		data = new ItemData("sapphire",	REQUIRED_SAPPHIRE,
+				"I need several gems to grind into dust to mix with the mithril. I need ",
 				" still.");
 		neededItems.put(6, data);
-		int i = 7;
-		data = new ItemData("black shield",	REQUIRED_BLACK_SHIELD , 
-				"I need ", 
+
+		data = new ItemData("black shield",	REQUIRED_BLACK_SHIELD,
+				"I need ",
 				" to form the framework for your new shield.");
-		neededItems.put(i, data);
+		neededItems.put(7, data);
 		
-		 i = 8;
-		data = new ItemData("magic plate shield",	REQUIRED_MAGIC_PLATE_SHIELD , 
-				"I need ", 
+		data = new ItemData("magic plate shield", REQUIRED_MAGIC_PLATE_SHIELD,
+				"I need ",
 				" for the pieces and parts for your new shield.");
-		neededItems.put(i, data);
+		neededItems.put(8, data);
 	
-		 i = 9;
-			data = new ItemData("gold bar",	REQUIRED_GOLD_BAR , 
-					"I need ", 
-					" to melt down with the mithril and iron.");
-			neededItems.put(i, data);
+		data = new ItemData("gold bar",	REQUIRED_GOLD_BAR,
+				"I need ",
+				" to melt down with the mithril and iron.");
+		neededItems.put(9, data);
 
-		 i = 10;
-			data = new ItemData("iron",	REQUIRED_IRON , 
-					"I need ", 
-					" to melt down with the mithril and gold.");
-			neededItems.put(i, data);
-		 i = 11;
-			data = new ItemData("black pearl",	REQUIRED_BLACK_PEARL , 
-					"I need ", 
-					" to crush into fine powder to sprinkle onto shield to give it a nice sheen.");
-			neededItems.put(i, data);
+		data = new ItemData("iron",	REQUIRED_IRON,
+				"I need ",
+				" to melt down with the mithril and gold.");
+		neededItems.put(10, data);
 
-		 i = 12;
-			data = new ItemData("shuriken",	REQUIRED_SHURIKEN , 
-					"I need ", 
-					" to melt down with the mithril, gold and iron. It is a 'secret' ingredient that only you and I know about. ;)");
-			neededItems.put(i, data);
-			i = 13;
-			data = new ItemData("marbles",	REQUIRED_MARBLES , 
-					"My son wants some new toys. I need ", 
-					" still.");
-			neededItems.put(i, data);
+		data = new ItemData("black pearl", REQUIRED_BLACK_PEARL,
+				"I need ",
+				" to crush into fine powder to sprinkle onto shield to give it a nice sheen.");
+		neededItems.put(11, data);
 
-			data = new ItemData("snowglobe",	REQUIRED_SNOWGLOBE, 
-					"I just LOVE those trinkets from athor. I need ", 
-					" still.");
-			neededItems.put(14, data);
+		data = new ItemData("shuriken",	REQUIRED_SHURIKEN,
+				"I need ",
+				" to melt down with the mithril, gold and iron. It is a 'secret' ingredient that only you and I know about. ;)");
+		neededItems.put(12, data);
+
+		data = new ItemData("marbles", REQUIRED_MARBLES,
+				"My son wants some new toys. I need ",
+				" still.");
+		neededItems.put(13, data);
+
+		data = new ItemData("snowglobe", REQUIRED_SNOWGLOBE,
+				"I just LOVE those trinkets from athor. I need ",
+				" still.");
+		neededItems.put(14, data);
 		return neededItems;
 	}
 
-	
 	protected static final class ItemData {
 
 		private int neededAmount;
@@ -171,7 +168,6 @@ public class StuffForBaldemar extends AbstractQuest {
 
 		public void setAmount(final int needed) {
 			neededAmount = needed;
-			
 		}
 
 		public String getName() {
@@ -188,7 +184,6 @@ public class StuffForBaldemar extends AbstractQuest {
 
 		public void subAmount(final String string) {
 			subAmount(Integer.parseInt(string));
-			
 		}
 
 		String getAnswer() {
@@ -208,12 +203,10 @@ public class StuffForBaldemar extends AbstractQuest {
 
 		public void subAmount(final int amount) {
 			neededAmount -= amount;
-			
 		}
 
 		public void resetAmount() {
 			neededAmount = requiredAmount;
-			
 		}
 	}
 
@@ -378,10 +371,8 @@ public class StuffForBaldemar extends AbstractQuest {
 							sb.append(id.getAlreadyBrought());
 						}
 						player.setQuest(QUEST_SLOT, sb.toString());
-							
 					}
 				}
-
 	
 				private boolean proceedItem(final Player player,
 						final EventRaiser engine, final ItemData itemData) {
@@ -491,7 +482,6 @@ public class StuffForBaldemar extends AbstractQuest {
 							+ neededSnowglobe + " snowglobe");
 				}
 			});
-
 	}
 
 	@Override
@@ -540,7 +530,7 @@ public class StuffForBaldemar extends AbstractQuest {
 			}
 			return res;
 	}
-	
+
 	@Override
 	public int getMinLevel() {
 		return 100;

--- a/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
+++ b/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
@@ -178,19 +178,11 @@ public class StuffForBaldemar extends AbstractQuest {
 			return itemName;
 		}
 
-		public String getPrefix() {
-			return itemPrefix;
-		}
-
-		public String getSuffix() {
-			return itemSuffix;
-		}
-
 		public void subAmount(final String string) {
 			subAmount(Integer.parseInt(string));
 		}
 
-		String getAnswer() {
+		public String getAnswer() {
 			return itemPrefix
 				+ Grammar.quantityplnoun(
 						neededAmount, itemName, "a")
@@ -443,19 +435,12 @@ public class StuffForBaldemar extends AbstractQuest {
 	}
 
 	private List<String> neededItemsWithAmounts(final Player player) {
-		String[] broughtTokens;
-		if (player.getQuest(QUEST_SLOT) != null) {
-			broughtTokens = player.getQuest(QUEST_SLOT).split(";");
-		} else {
-			broughtTokens = new String[neededItems.size() + 1];
-			Arrays.fill(broughtTokens, "0");
-		}
-
+		int[] broughtItems = broughtItems(player);
 		List<String> neededItemsWithAmounts = new LinkedList<>();
 		for (int i = 1; i <= neededItems.size(); i++) {
 			ItemData item = neededItems.get(i);
 			int required = item.requiredAmount;
-			int brought = Integer.parseInt(broughtTokens[i]);
+			int brought = broughtItems[i - 1];
 			int neededAmount = required - brought;
 			if (neededAmount > 0) {
 				neededItemsWithAmounts.add(neededItem(neededAmount, item.itemName));
@@ -463,6 +448,19 @@ public class StuffForBaldemar extends AbstractQuest {
 		}
 
 		return neededItemsWithAmounts;
+	}
+
+	private int[] broughtItems(final Player player) {
+		int[] brought = new int[neededItems.size()];
+		if (player.getQuest(QUEST_SLOT) != null) {
+			String[] broughtTokens = player.getQuest(QUEST_SLOT).split(";");
+			for (int i = 1; i < broughtTokens.length; i++) {
+				brought[i - 1] = Integer.parseInt(broughtTokens[i]);
+			}
+		} else {
+			Arrays.fill(brought, 0);
+		}
+		return brought;
 	}
 
 	private String neededItem(int neededAmount, String itemName) {
@@ -484,7 +482,7 @@ public class StuffForBaldemar extends AbstractQuest {
 	public String getName() {
 		return "StuffForBaldemar";
 	}
-	
+
 	@Override
 	public List<String> getHistory(final Player player) {
 			final List<String> res = new ArrayList<String>();
@@ -528,7 +526,7 @@ public class StuffForBaldemar extends AbstractQuest {
 	public String getNPCName() {
 		return "Baldemar";
 	}
-	
+
 	@Override
 	public String getRegion() {
 		return Region.FADO_CAVES;

--- a/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
+++ b/src/games/stendhal/server/maps/quests/StuffForBaldemar.java
@@ -242,35 +242,9 @@ public class StuffForBaldemar extends AbstractQuest {
 
 	private static final int REQUIRED_SNOWGLOBE = 1;
 
-	private static final String I_WILL_NEED_MANY_THINGS = "I will need many, many things: "
-							+ REQUIRED_MITHRIL_BAR
-							+ " mithril bars, "
-							+ REQUIRED_OBSIDIAN
-							+ " obsidian, "
-							+ REQUIRED_DIAMOND
-							+ " diamond, "
-							+ REQUIRED_EMERALD
-							+ " emeralds, "
-							+ REQUIRED_CARBUNCLE
-							+ " carbuncles, "
-							+ REQUIRED_SAPPHIRE
-							+ " sapphires, "
-							+ REQUIRED_BLACK_SHIELD
-							+ " black shield, "
-							+ REQUIRED_MAGIC_PLATE_SHIELD
-							+ " magic plate shield, "
-							+ REQUIRED_GOLD_BAR
-							+ " gold bars, "
-							+ REQUIRED_IRON
-							+ " iron bars, "
-							+ REQUIRED_BLACK_PEARL
-							+ " black pearls, " 
-							+ REQUIRED_SHURIKEN
-							+ " shuriken, "
-							+ REQUIRED_MARBLES
-							+ " marbles and "
-							+ REQUIRED_SNOWGLOBE
-							+ " snowglobe. Come back when you have them in the same #exact order!";
+	private static final String I_WILL_NEED_MANY_THINGS = "I will need many, many things: ";
+
+	private static final String IN_EXACT_ORDER = "Come back when you have them in the same #exact order!";
 
 	private static final int REQUIRED_MINUTES = 10;
 
@@ -280,7 +254,7 @@ public class StuffForBaldemar extends AbstractQuest {
 	public String getSlotName() {
 		return QUEST_SLOT;
 	}
-	
+
 	private void step_1() {
 		final SpeakerNPC npc = npcs.get("Baldemar");
 
@@ -308,7 +282,8 @@ public class StuffForBaldemar extends AbstractQuest {
 			new ChatAction() {
 				@Override
 				public void fire(final Player player, final Sentence sentence, final EventRaiser raiser) {
-					raiser.say(I_WILL_NEED_MANY_THINGS);
+					String need = I_WILL_NEED_MANY_THINGS + itemsStillNeeded(player) + ". " + IN_EXACT_ORDER;
+					raiser.say(need);
 					player.setQuest(QUEST_SLOT, "start;0;0;0;0;0;0;0;0;0;0;0;0;0;0");
 
 				}
@@ -468,13 +443,19 @@ public class StuffForBaldemar extends AbstractQuest {
 	}
 
 	private List<String> neededItemsWithAmounts(final Player player) {
-		String[] tokens = player.getQuest(QUEST_SLOT).split(";");
+		String[] broughtTokens;
+		if (player.getQuest(QUEST_SLOT) != null) {
+			broughtTokens = player.getQuest(QUEST_SLOT).split(";");
+		} else {
+			broughtTokens = new String[neededItems.size() + 1];
+			Arrays.fill(broughtTokens, "0");
+		}
 
 		List<String> neededItemsWithAmounts = new LinkedList<>();
 		for (int i = 1; i <= neededItems.size(); i++) {
 			ItemData item = neededItems.get(i);
 			int required = item.requiredAmount;
-			int brought = Integer.parseInt(tokens[i]);
+			int brought = Integer.parseInt(broughtTokens[i]);
 			int neededAmount = required - brought;
 			if (neededAmount > 0) {
 				neededItemsWithAmounts.add(neededItem(neededAmount, item.itemName));

--- a/src/games/stendhal/server/maps/quests/StuffForVulcanus.java
+++ b/src/games/stendhal/server/maps/quests/StuffForVulcanus.java
@@ -12,8 +12,8 @@
  ***************************************************************************/
 package games.stendhal.server.maps.quests;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import games.stendhal.common.MathHelper;
@@ -28,7 +28,6 @@ import games.stendhal.server.entity.npc.SpeakerNPC;
 import games.stendhal.server.entity.npc.action.SetQuestAndModifyKarmaAction;
 import games.stendhal.server.entity.npc.condition.AndCondition;
 import games.stendhal.server.entity.npc.condition.GreetingMatchesNameCondition;
-import games.stendhal.server.entity.npc.condition.QuestStartedCondition;
 import games.stendhal.server.entity.npc.condition.QuestStateStartsWithCondition;
 import games.stendhal.server.entity.player.Player;
 import games.stendhal.server.maps.Region;
@@ -205,7 +204,7 @@ public class StuffForVulcanus extends AbstractQuest {
 
 		npc.add(ConversationStates.ATTENDING,
 			Arrays.asList("forge", "missing"), 
-			new QuestStartedCondition(QUEST_SLOT),
+			new QuestStateStartsWithCondition(QUEST_SLOT, "start;"),
 			ConversationStates.ATTENDING,
 			null,
 			new ChatAction() {
@@ -259,35 +258,39 @@ public class StuffForVulcanus extends AbstractQuest {
 	public String getName() {
 		return "StuffForVulcanus";
 	}
-	
+
 	@Override
 	public List<String> getHistory(final Player player) {
-			final List<String> res = new ArrayList<String>();
-			if (!player.hasQuest(QUEST_SLOT)) {
-				return res;
-			}
-			final String questState = player.getQuest(QUEST_SLOT);
-			res.add("I met Vulcanus in Kotoch.");
-			if (questState.equals("rejected")) {
-				res.add("I don't want an immortal sword.");
-				return res;
-			} 
-			res.add("To forge the immortal sword I must bring several things to Vulcanus.");
-			if (questState.startsWith("start") && !broughtAllItems(questState)) {
-				res.add("I still need to bring " + questLogic.itemsStillNeeded(player) + ", in this order.");
-			} else if (broughtAllItems(questState) || !questState.startsWith("start")) {
-				res.add("I took all the special items to Vulcanus.");
-			}
-			if(broughtAllItems(questState) && !player.hasKilled("giant")){
-				res.add("I must prove my worth and kill a giant, before I am worthy of this prize.");
-			} 
-			if (questState.startsWith("forging")) {
-				res.add("Vulcanus, son of gods himself, now forges my immortal sword.");
-			} 
-			if (isCompleted(player)) {
-				res.add("Gold bars and giant hearts together with the forging from a god's son made me a sword of which I can be proud.");
-			}
+		final List<String> res = new LinkedList<>();
+		if (!player.hasQuest(QUEST_SLOT)) {
 			return res;
+		}
+		final String questState = player.getQuest(QUEST_SLOT);
+		res.add("I met Vulcanus in Kotoch.");
+		if (questState.equals("rejected")) {
+			res.add("I don't want an immortal sword.");
+			return res;
+		}
+		res.add("To forge the immortal sword I must bring several things to Vulcanus.");
+		if (questState.startsWith("start") && !broughtAllItems(questState)) {
+			String suffix = ".";
+			if (questLogic.neededItemsWithAmounts(player).size() > 1) {
+				suffix = ", in this order.";
+			}
+			res.add("I still need to bring " + questLogic.itemsStillNeeded(player) + suffix);
+		} else if (broughtAllItems(questState) || !questState.startsWith("start")) {
+			res.add("I took all the special items to Vulcanus.");
+		}
+		if (broughtAllItems(questState) && !player.hasKilled("giant")) {
+			res.add("I must prove my worth and kill a giant, before I am worthy of this prize.");
+		}
+		if (questState.startsWith("forging")) {
+			res.add("Vulcanus, son of gods himself, now forges my immortal sword.");
+		}
+		if (isCompleted(player)) {
+			res.add("Gold bars and giant hearts together with the forging from a god's son made me a sword of which I can be proud.");
+		}
+		return res;
 	}
 
 	private boolean broughtAllItems(final String questState) {

--- a/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
+++ b/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
@@ -1,3 +1,14 @@
+/***************************************************************************
+ *                   (C) Copyright 2003-2016 - Stendhal                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
 package games.stendhal.server.maps.quests.logic;
 
 import java.util.Arrays;

--- a/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
+++ b/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
@@ -1,0 +1,140 @@
+package games.stendhal.server.maps.quests.logic;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import games.stendhal.common.grammar.Grammar;
+import games.stendhal.server.entity.npc.EventRaiser;
+import games.stendhal.server.entity.player.Player;
+import games.stendhal.server.maps.quests.IQuest;
+
+public class BringOrderedListOfItemsQuestLogic {
+
+	private ItemCollector itemCollector;
+
+	private IQuest quest;
+
+	public String itemsStillNeeded(final Player player) {
+		return itemsStillNeeded(player, false);
+	}
+
+	public String itemsStillNeededWithHash(final Player player) {
+		return itemsStillNeeded(player, true);
+	}
+
+	private String itemsStillNeeded(final Player player, boolean withHash) {
+		List<String> neededItemsWithAmounts = neededItemsWithAmounts(player, withHash);
+
+		// TODO try Grammar.enumerateCollection
+		StringBuilder all = new StringBuilder();
+		for (int i = 0; i < neededItemsWithAmounts.size(); i++) {
+			if (i != 0 && i == neededItemsWithAmounts.size() - 1) {
+				all.append(" and ");
+			}
+			all.append(neededItemsWithAmounts.get(i));
+			if (i < neededItemsWithAmounts.size() - 2) {
+				all.append(", ");
+			}
+		}
+		return all.toString();
+	}
+
+	private List<String> neededItemsWithAmounts(final Player player, boolean withHash) {
+		int[] broughtItems = broughtItems(player);
+		List<String> neededItemsWithAmounts = new LinkedList<>();
+		for (int i = 0; i < itemCollector.requiredItems().size(); i++) {
+			ItemCollectorData item = itemCollector.requiredItems().get(i);
+			int required = item.getRequiredAmount();
+			int brought = broughtItems[i];
+			int neededAmount = required - brought;
+			if (neededAmount > 0) {
+				neededItemsWithAmounts.add(neededItem(neededAmount, item.getName(), withHash));
+			}
+		}
+
+		return neededItemsWithAmounts;
+	}
+
+	private int[] broughtItems(final Player player) {
+		int[] brought = new int[itemCollector.requiredItems().size()];
+		String questStatus = player.getQuest(quest.getSlotName());
+		if (questStatus != null) {
+			String[] broughtTokens = questStatus.split(";");
+			for (int i = 1; i < broughtTokens.length; i++) {
+				brought[i - 1] = Integer.parseInt(broughtTokens[i]);
+			}
+		} else {
+			Arrays.fill(brought, 0);
+		}
+		return brought;
+	}
+
+	private String neededItem(int neededAmount, String itemName, boolean withHash) {
+		if (!withHash) {
+			return Grammar.quantityplnoun(neededAmount, itemName, "a");
+		} else {
+			return Grammar.quantityplnounWithHash(neededAmount, itemName);
+		}
+	}
+
+	public boolean proceedItems(final Player player, final EventRaiser eventRaiser) {
+		String questStatus = player.getQuest(quest.getSlotName());
+		final String[] tokens = questStatus.split(";");
+
+		int idx1 = 1;
+		for (ItemCollectorData itemdata : itemCollector.requiredItems()) {
+			itemdata.resetAmount();
+			itemdata.subtractAmount(tokens[idx1]);
+			idx1++;
+		}
+
+		boolean missingSomething = false;
+
+		int size = itemCollector.requiredItems().size();
+		for (int idx = 0; !missingSomething && idx < size; idx++) {
+			ItemCollectorData itemData = itemCollector.requiredItems().get(idx);
+			missingSomething = proceedItem(player, eventRaiser, itemData);
+		}
+
+		return missingSomething;
+	}
+
+	private boolean proceedItem(final Player player, final EventRaiser engine, final ItemCollectorData itemData) {
+		if (itemData.getStillNeeded() > 0) {
+
+			if (player.isEquipped(itemData.getName(), itemData.getStillNeeded())) {
+				player.drop(itemData.getName(), itemData.getStillNeeded());
+				itemData.subtractAmount(itemData.getStillNeeded());
+			} else {
+				final int amount = player.getNumberOfEquipped(itemData.getName());
+				if (amount > 0) {
+					player.drop(itemData.getName(), amount);
+					itemData.subtractAmount(amount);
+				}
+
+				engine.say(itemData.getAnswer());
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public void updateQuantitiesInQuestStatus(final Player player) {
+		StringBuilder sb = new StringBuilder(30);
+		sb.append("start");
+		for (ItemCollectorData id : itemCollector.requiredItems()) {
+			sb.append(";");
+			sb.append(id.getAlreadyBrought());
+		}
+		player.setQuest(quest.getSlotName(), sb.toString());
+	}
+
+	public void setItemCollector(ItemCollector itemCollector) {
+		this.itemCollector = itemCollector;
+	}
+
+	public void setQuest(IQuest quest) {
+		this.quest = quest;
+	}
+}

--- a/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
+++ b/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
@@ -20,16 +20,41 @@ import games.stendhal.server.entity.npc.EventRaiser;
 import games.stendhal.server.entity.player.Player;
 import games.stendhal.server.maps.quests.IQuest;
 
+/**
+ * Basic behavior for quests which are based on bringing a list of items to an
+ * NPC, in a specific order. The NPC keeps track of the items already brought to
+ * him.
+ */
 public class BringOrderedListOfItemsQuestLogic {
 
 	private ItemCollector itemCollector;
 
 	private IQuest quest;
 
+	/**
+	 * Gets a sentence to be said by the NPC, enumerating the items that still
+	 * need to be brought. The item names are not prefixed by a hash. For a
+	 * variant where they are, see {@link #itemsStillNeededWithHash(Player)}.
+	 *
+	 * @param player
+	 *            the player which needs to bring items
+	 * @return an enumeration of still needed items
+	 * @see #itemsStillNeededWithHash(Player)
+	 */
 	public String itemsStillNeeded(final Player player) {
 		return itemsStillNeeded(player, false);
 	}
 
+	/**
+	 * Gets a sentence to be said by the NPC, enumerating the items that still
+	 * need to be brought. The item names are prefixed by a hash. For a variant
+	 * where they aren't, see {@link #itemsStillNeeded(Player)}.
+	 *
+	 * @param player
+	 *            the player which needs to bring items
+	 * @return an enumeration of still needed items
+	 * @see #itemsStillNeeded(Player)
+	 */
 	public String itemsStillNeededWithHash(final Player player) {
 		return itemsStillNeeded(player, true);
 	}
@@ -51,6 +76,18 @@ public class BringOrderedListOfItemsQuestLogic {
 		return all.toString();
 	}
 
+	/**
+	 * Gets a list of items that still need to be brought. Each item is prefixed
+	 * by the quantity still needed. An example list element: "5 iron bars". For
+	 * a sentence that groups the list items, see
+	 * {@link #itemsStillNeeded(Player)}.
+	 *
+	 * @param player
+	 *            the player which needs to bring items
+	 * @return a list of still needed items, along with their respective
+	 *         quantities
+	 * @see #itemsStillNeeded(Player)
+	 */
 	public List<String> neededItemsWithAmounts(final Player player) {
 		return neededItemsWithAmounts(player, false);
 	}
@@ -93,6 +130,16 @@ public class BringOrderedListOfItemsQuestLogic {
 		}
 	}
 
+	/**
+	 * Give items to the NPC, in the required order.
+	 *
+	 * @param player
+	 *            the player which needs to bring items
+	 * @param eventRaiser
+	 *            the NPC that should say what's the next item to bring
+	 * @return {@code true} if there are still items to bring after this, {@code
+	 *         false} otherwise
+	 */
 	public boolean proceedItems(final Player player, final EventRaiser eventRaiser) {
 		String questStatus = player.getQuest(quest.getSlotName());
 		final String[] tokens = questStatus.split(";");
@@ -135,6 +182,13 @@ public class BringOrderedListOfItemsQuestLogic {
 		return false;
 	}
 
+	/**
+	 * Updates the status of the player's quest with the quantities of already
+	 * brought items.
+	 *
+	 * @param player
+	 *            the player for which to update the quest status
+	 */
 	public void updateQuantitiesInQuestStatus(final Player player) {
 		StringBuilder sb = new StringBuilder(30);
 		sb.append("start");
@@ -145,10 +199,22 @@ public class BringOrderedListOfItemsQuestLogic {
 		player.setQuest(quest.getSlotName(), sb.toString());
 	}
 
+	/**
+	 * Sets the item collector to be used.
+	 *
+	 * @param itemCollector
+	 *            an {@link ItemCollector}
+	 */
 	public void setItemCollector(ItemCollector itemCollector) {
 		this.itemCollector = itemCollector;
 	}
 
+	/**
+	 * Sets the quest on which to apply the logic.
+	 *
+	 * @param quest
+	 *            a quest
+	 */
 	public void setQuest(IQuest quest) {
 		this.quest = quest;
 	}

--- a/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
+++ b/src/games/stendhal/server/maps/quests/logic/BringOrderedListOfItemsQuestLogic.java
@@ -40,6 +40,10 @@ public class BringOrderedListOfItemsQuestLogic {
 		return all.toString();
 	}
 
+	public List<String> neededItemsWithAmounts(final Player player) {
+		return neededItemsWithAmounts(player, false);
+	}
+
 	private List<String> neededItemsWithAmounts(final Player player, boolean withHash) {
 		int[] broughtItems = broughtItems(player);
 		List<String> neededItemsWithAmounts = new LinkedList<>();

--- a/src/games/stendhal/server/maps/quests/logic/ItemCollector.java
+++ b/src/games/stendhal/server/maps/quests/logic/ItemCollector.java
@@ -1,0 +1,19 @@
+package games.stendhal.server.maps.quests.logic;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ItemCollector {
+
+	private final List<ItemCollectorData> requiredItems = new LinkedList<>();
+
+	public ItemCollectorSetters require() {
+		ItemCollectorData itemData = new ItemCollectorData();
+		requiredItems.add(itemData);
+		return itemData;
+	}
+
+	public List<ItemCollectorData> requiredItems() {
+		return requiredItems;
+	}
+}

--- a/src/games/stendhal/server/maps/quests/logic/ItemCollector.java
+++ b/src/games/stendhal/server/maps/quests/logic/ItemCollector.java
@@ -1,18 +1,55 @@
+/***************************************************************************
+ *                   (C) Copyright 2003-2016 - Stendhal                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
 package games.stendhal.server.maps.quests.logic;
 
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Holds a list of items to collect, together with the required quantities and
+ * messages to describe them ({@link ItemCollectorData}). Uses
+ * {@link ItemCollectorSetters} to build the list in a fluent way.
+ *
+ * Example usage:
+ *
+ * <pre>
+ * new ItemCollector().require().item("wood").pieces(2).bySaying("Bring me %s, please.");
+ * </pre>
+ */
 public class ItemCollector {
 
 	private final List<ItemCollectorData> requiredItems = new LinkedList<>();
 
+	/**
+	 * Starts adding a new required item. Returns an
+	 * {@link ItemCollectorSetters} to allow describing the required item in a
+	 * fluent way. It may add a single item. To build a list of different items,
+	 * call the method multiple times. See the class documentation for example
+	 * usage.
+	 *
+	 * @return the collector setters
+	 */
 	public ItemCollectorSetters require() {
 		ItemCollectorData itemData = new ItemCollectorData();
 		requiredItems.add(itemData);
 		return itemData;
 	}
 
+	/**
+	 * Gets the list of required items, in the order that they were added by
+	 * subsequent calls to {@link #require()}.
+	 *
+	 * @return a list of items to collect
+	 */
 	public List<ItemCollectorData> requiredItems() {
 		return requiredItems;
 	}

--- a/src/games/stendhal/server/maps/quests/logic/ItemCollectorData.java
+++ b/src/games/stendhal/server/maps/quests/logic/ItemCollectorData.java
@@ -1,0 +1,64 @@
+package games.stendhal.server.maps.quests.logic;
+
+import games.stendhal.common.grammar.Grammar;
+
+public class ItemCollectorData implements ItemCollectorSetters {
+
+	private String itemName;
+	private int requiredAmount = 1;
+	private String message;
+
+	private int stillNeededAmount = 1;
+
+	@Override
+	public ItemCollectorSetters item(String itemName) {
+		this.itemName = itemName;
+		return this;
+	}
+
+	@Override
+	public ItemCollectorSetters pieces(int count) {
+		this.requiredAmount = count;
+		this.stillNeededAmount = count;
+		return this;
+	}
+
+	@Override
+	public ItemCollectorSetters bySaying(String message) {
+		this.message = message;
+		return this;
+	}
+
+	public void subtractAmount(final int amount) {
+		stillNeededAmount -= amount;
+	}
+
+	public void subtractAmount(final String string) {
+		subtractAmount(Integer.parseInt(string));
+	}
+
+	public void resetAmount() {
+		stillNeededAmount = requiredAmount;
+	}
+
+	public int getAlreadyBrought() {
+		return requiredAmount - stillNeededAmount;
+	}
+
+	public int getStillNeeded() {
+		return stillNeededAmount;
+	}
+
+	public int getRequiredAmount() {
+		return requiredAmount;
+	}
+
+	public String getName() {
+		return itemName;
+	}
+
+	public String getAnswer() {
+		String neededItems = Grammar.quantityplnoun(stillNeededAmount, itemName, "a");
+		return String.format(message, neededItems);
+	}
+}

--- a/src/games/stendhal/server/maps/quests/logic/ItemCollectorData.java
+++ b/src/games/stendhal/server/maps/quests/logic/ItemCollectorData.java
@@ -1,7 +1,24 @@
+/***************************************************************************
+ *                   (C) Copyright 2003-2016 - Stendhal                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
 package games.stendhal.server.maps.quests.logic;
 
 import games.stendhal.common.grammar.Grammar;
 
+/**
+ * Container for a collectible item. Holds information about the initial
+ * required amount, as well as the current still needed amount, and a message
+ * describing the need of the item. The recommended way of building an instance
+ * of this type if by using {@link ItemCollector#require()}.
+ */
 public class ItemCollectorData implements ItemCollectorSetters {
 
 	private String itemName;
@@ -29,34 +46,78 @@ public class ItemCollectorData implements ItemCollectorSetters {
 		return this;
 	}
 
+	/**
+	 * Subtract the specified amount from the still needed amount.
+	 *
+	 * @param amount
+	 *            how much to subtract from the still needed amount
+	 */
 	public void subtractAmount(final int amount) {
 		stillNeededAmount -= amount;
 	}
 
-	public void subtractAmount(final String string) {
-		subtractAmount(Integer.parseInt(string));
+	/**
+	 * Subtract the specified amount from the still needed amount.
+	 *
+	 * @param amount
+	 *            a number indicating how much to subtract from the still needed
+	 *            amount
+	 */
+	public void subtractAmount(final String amount) {
+		subtractAmount(Integer.parseInt(amount));
 	}
 
+	/**
+	 * Makes the still needed amount equal to the initial required amount.
+	 */
 	public void resetAmount() {
 		stillNeededAmount = requiredAmount;
 	}
 
+	/**
+	 * Gets the number of already collected items.
+	 *
+	 * @return the difference between the initial required amount and the still
+	 *         needed amount
+	 */
 	public int getAlreadyBrought() {
 		return requiredAmount - stillNeededAmount;
 	}
 
+	/**
+	 * Gets the number of items that are still needed.
+	 *
+	 * @return the difference between the initial required amount and the amount
+	 *         already brought
+	 */
 	public int getStillNeeded() {
 		return stillNeededAmount;
 	}
 
+	/**
+	 * Gets the number of initially required items.
+	 *
+	 * @return the number of initially required items
+	 */
 	public int getRequiredAmount() {
 		return requiredAmount;
 	}
 
+	/**
+	 * Gets the name of the item to collect.
+	 *
+	 * @return the name of the item to collect
+	 */
 	public String getName() {
 		return itemName;
 	}
 
+	/**
+	 * Uses the configured message to describe the need of this item.
+	 *
+	 * @return a message describing the need of this item.
+	 * @see #bySaying(String)
+	 */
 	public String getAnswer() {
 		String neededItems = Grammar.quantityplnoun(stillNeededAmount, itemName, "a");
 		return String.format(message, neededItems);

--- a/src/games/stendhal/server/maps/quests/logic/ItemCollectorSetters.java
+++ b/src/games/stendhal/server/maps/quests/logic/ItemCollectorSetters.java
@@ -1,0 +1,10 @@
+package games.stendhal.server.maps.quests.logic;
+
+public interface ItemCollectorSetters {
+
+	ItemCollectorSetters item(String itemName);
+
+	ItemCollectorSetters pieces(int count);
+
+	ItemCollectorSetters bySaying(String message);
+}

--- a/src/games/stendhal/server/maps/quests/logic/ItemCollectorSetters.java
+++ b/src/games/stendhal/server/maps/quests/logic/ItemCollectorSetters.java
@@ -1,10 +1,48 @@
+/***************************************************************************
+ *                   (C) Copyright 2003-2016 - Stendhal                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
 package games.stendhal.server.maps.quests.logic;
 
+/**
+ * Allows setting attributes for an {@link ItemCollector}.
+ */
 public interface ItemCollectorSetters {
 
+	/**
+	 * Sets the name of an item to collect.
+	 *
+	 * @param itemName
+	 *            an item name
+	 * @return this object to allow method call chaining
+	 */
 	ItemCollectorSetters item(String itemName);
 
+	/**
+	 * Sets the number of required instances for an item to collect.
+	 *
+	 * @param count
+	 *            the number of items of the same kind
+	 * @return this object to allow method call chaining
+	 */
 	ItemCollectorSetters pieces(int count);
 
+	/**
+	 * Sets the message to describe an item to collect. Should contain a "%s"
+	 * where the count and name of the item are to be replaced. For example, the
+	 * message "I still need %s." may appear as "I still need 6 pieces of iron."
+	 *
+	 * @param message
+	 *            a message to be said by the NPC when talking about the item to
+	 *            collect
+	 * @return this object to allow method call chaining
+	 */
 	ItemCollectorSetters bySaying(String message);
 }

--- a/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
@@ -31,7 +31,6 @@ import games.stendhal.server.entity.npc.SpeakerNPC;
 import games.stendhal.server.entity.npc.fsm.Engine;
 import games.stendhal.server.entity.player.Player;
 import games.stendhal.server.maps.magic.theater.MithrilShieldForgerNPC;
-import games.stendhal.server.maps.quests.StuffForBaldemar.ItemData;
 import utilities.PlayerTestHelper;
 import utilities.QuestHelper;
 import utilities.ZonePlayerAndNPCTestImpl;
@@ -228,7 +227,7 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 		en.setCurrentState(ConversationStates.IDLE);
 		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;15;0");
 		en.step(player, "hi");
-		assertEquals("I just LOVE those trinkets from athor. I need a snowglobe still.", getReply(baldemar));
+		assertEquals("I just LOVE those trinkets from Athor. I need a snowglobe still.", getReply(baldemar));
 	}
 
 	@Test
@@ -310,27 +309,6 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 		en.step(player, "hi");
 
 		assertEquals("start;20;1;1;5;10;10;1;1;10;20;10;20;15;1", player.getQuest(questSlot));
-	}
-
-	/**
-	 * Tests for itemData.
-	 */
-	@Test
-	public void testItemData() {
-		int needed = 20;
-		ItemData id = new ItemData("name", needed, "prefix ", " suffix");
-		assertEquals(needed, id.getStillNeeded());
-
-		id.setAmount(15);
-		assertEquals(15, id.getStillNeeded());
-		assertEquals(needed, id.getRequired());
-		assertEquals("name", id.getName());
-
-		id.subAmount("10");
-		assertEquals(5, id.getStillNeeded());
-		assertEquals(needed, id.getRequired());
-		assertEquals(15, id.getAlreadyBrought());
-		assertEquals("prefix 5 names suffix", id.getAnswer());
 	}
 
 	@Test

--- a/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
@@ -81,7 +81,7 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 	public void testAcceptQuest() {
 		en.setCurrentState(ConversationStates.QUEST_OFFERED);
 		en.step(player, "yes");
-		assertEquals("I will need many, many things: 20 mithril bars, 1 obsidian, 1 diamond, 5 emeralds,10 carbuncles, 10 sapphires, 1 black shield, 1 magic plate shield, 10 gold bars, 20 iron bars, 10 black pearls, 20 shuriken, 15 marbles and 1 snowglobe. Come back when you have them in the same #exact order!", getReply(baldemar));
+		assertEquals("I will need many, many things: 20 mithril bars, 1 obsidian, 1 diamond, 5 emeralds, 10 carbuncles, 10 sapphires, 1 black shield, 1 magic plate shield, 10 gold bars, 20 iron bars, 10 black pearls, 20 shuriken, 15 marbles and 1 snowglobe. Come back when you have them in the same #exact order!", getReply(baldemar));
 		
 		en.step(player, "exact");
 		assertEquals("As I have listed them here, you must provide them in that order.", getReply(baldemar));
@@ -268,12 +268,47 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 	}
 
 	@Test
-	public void testAskToForgeWithoutAllItems() {
-		Engine en = baldemar.getEngine();
+	public void testAskToForgeWithoutAnyItem() {
+		en.setCurrentState(ConversationStates.ATTENDING);
+		player.setQuest(questSlot, "start;0;0;0;0;0;0;0;0;0;0;0;0;0;0");
+		en.step(player, "forge");
 
+		assertEquals("I need 20 mithril bars, an obsidian, a diamond, 5 emeralds, 10 carbuncles, 10 sapphires, a black shield, a magic plate shield, 10 gold bars, 20 pieces of iron, 10 black pearls, 20 shurikens, 15 marbles and a snowglobe.", getReply(baldemar));
+	}
+
+	@Test
+	public void testAskToForgeWithoutLastThreeItems() {
+		en.setCurrentState(ConversationStates.ATTENDING);
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;10;0;0");
+		en.step(player, "forge");
+
+		assertEquals("I need 10 shurikens, 15 marbles and a snowglobe.", getReply(baldemar));
+	}
+
+	@Test
+	public void testAskToForgeWithoutLastTwoItems() {
 		en.setCurrentState(ConversationStates.ATTENDING);
 		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;12;0");
 		en.step(player, "forge");
-		assertEquals("I will need 0 mithril bars, 0 obsidian, 0 diamond, 0 emeralds, 0 carbuncles, 0 sapphires, 0 black shield, 0 magic plate shield, 0 gold bars, 0 iron bars, 0 black pearls, 0 shuriken, 3 marbles and 1 snowglobe", getReply(baldemar));
+
+		assertEquals("I need 3 marbles and a snowglobe.", getReply(baldemar));
+	}
+
+	@Test
+	public void testAskToForgeWithoutLastItem() {
+		en.setCurrentState(ConversationStates.ATTENDING);
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;15;0");
+		en.step(player, "forge");
+
+		assertEquals("I need a snowglobe.", getReply(baldemar));
+	}
+
+	@Test
+	public void testAskToForgeWithAllItems() {
+		en.setCurrentState(ConversationStates.ATTENDING);
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;15;1");
+		en.step(player, "forge");
+
+		assertEquals(StuffForBaldemar.TALK_NEED_KILL_GIANT, getReply(baldemar));
 	}
 }

--- a/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
@@ -45,6 +45,7 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 	private static final String HISTORY_START = "Baldemar asked me to bring him many things.";
 	private static final String HISTORY_NEED_ITEMS_PREFIX = "I still need to bring ";
 	private static final String HISTORY_NEED_ITEMS_SUFFIX = ", in this order.";
+	private static final String HISTORY_NEED_ONE_ITEM_SUFFIX = ".";
 	private static final String HISTORY_BROUGHT_ALL_ITEMS = "I took all the special items to Baldemar.";
 	private static final String HISTORY_NEED_KILL_GIANT = "I will need to bravely face a black giant alone, before I am worthy of this shield.";
 	private static final String HISTORY_REWARD_PENDING = "Baldemar is forging my mithril shield!";
@@ -228,6 +229,9 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;15;0");
 		en.step(player, "hi");
 		assertEquals("I just LOVE those trinkets from Athor. I need a snowglobe still.", getReply(baldemar));
+
+		String neededItems = "a snowglobe";
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_NEED_ITEMS_PREFIX + neededItems + HISTORY_NEED_ONE_ITEM_SUFFIX);
 	}
 
 	@Test

--- a/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
@@ -81,7 +81,7 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 	public void testAcceptQuest() {
 		en.setCurrentState(ConversationStates.QUEST_OFFERED);
 		en.step(player, "yes");
-		assertEquals("I will need many, many things: 20 mithril bars, 1 obsidian, 1 diamond, 5 emeralds, 10 carbuncles, 10 sapphires, 1 black shield, 1 magic plate shield, 10 gold bars, 20 iron bars, 10 black pearls, 20 shuriken, 15 marbles and 1 snowglobe. Come back when you have them in the same #exact order!", getReply(baldemar));
+		assertEquals("I will need many, many things: 20 mithril bars, an obsidian, a diamond, 5 emeralds, 10 carbuncles, 10 sapphires, a black shield, a magic plate shield, 10 gold bars, 20 pieces of iron, 10 black pearls, 20 shurikens, 15 marbles and a snowglobe. Come back when you have them in the same #exact order!", getReply(baldemar));
 		
 		en.step(player, "exact");
 		assertEquals("As I have listed them here, you must provide them in that order.", getReply(baldemar));

--- a/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
@@ -257,8 +257,6 @@ public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals(15, id.getStillNeeded());
 		assertEquals(needed, id.getRequired());
 		assertEquals("name", id.getName());
-		assertEquals("prefix ", id.getPrefix());
-		assertEquals(" suffix", id.getSuffix());
 
 		id.subAmount("10");
 		assertEquals(5, id.getStillNeeded());

--- a/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForBaldemarTest.java
@@ -13,189 +13,237 @@
 package games.stendhal.server.maps.quests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static utilities.SpeakerNPCTestHelper.getReply;
-import games.stendhal.server.entity.npc.ConversationStates;
-import games.stendhal.server.entity.npc.NPCList;
-import games.stendhal.server.entity.npc.SpeakerNPC;
-import games.stendhal.server.entity.npc.fsm.Engine;
-import games.stendhal.server.entity.player.Player;
-import games.stendhal.server.maps.MockStendlRPWorld;
-import games.stendhal.server.maps.quests.StuffForBaldemar.ItemData;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import games.stendhal.server.core.engine.SingletonRepository;
+import games.stendhal.server.core.engine.StendhalRPZone;
+import games.stendhal.server.entity.npc.ConversationStates;
+import games.stendhal.server.entity.npc.SpeakerNPC;
+import games.stendhal.server.entity.npc.fsm.Engine;
+import games.stendhal.server.entity.player.Player;
+import games.stendhal.server.maps.magic.theater.MithrilShieldForgerNPC;
+import games.stendhal.server.maps.quests.StuffForBaldemar.ItemData;
 import utilities.PlayerTestHelper;
 import utilities.QuestHelper;
+import utilities.ZonePlayerAndNPCTestImpl;
 
-public class StuffForBaldemarTest {
+public class StuffForBaldemarTest extends ZonePlayerAndNPCTestImpl {
 
-	private static StuffForBaldemar sfb;
-	private static SpeakerNPC baldemar;
+	private static final String ZONE_NAME = "int_magic_theater";
+	private static final String NPC_NAME = "Baldemar";
+
+	private Player player;
+	private SpeakerNPC baldemar;
+	private Engine en;
+
+	private StuffForBaldemar quest;
+	private String questSlot;
+
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		MockStendlRPWorld.get();
 		QuestHelper.setUpBeforeClass();
-		baldemar = new SpeakerNPC("Baldemar");
-		NPCList.get().add(baldemar);
-		sfb = new StuffForBaldemar();
-		sfb.addToWorld();
+		setupZone(ZONE_NAME);
+	}
+	
+	public StuffForBaldemarTest() {
+		super(ZONE_NAME, NPC_NAME);
 	}
 
-	
-	
-	/**
-	 * Tests for getSlotName.
-	 */
-	@Test
-	public void testGetSlotName() {
-		assertEquals("mithrilshield_quest", new StuffForBaldemar().getSlotName());
+	@Override
+	@Before
+	public void setUp() {
+		final StendhalRPZone zone = new StendhalRPZone(ZONE_NAME);
+		new MithrilShieldForgerNPC().configureZone(zone, null);
+
+		quest = new StuffForBaldemar();
+		quest.addToWorld();
+
+		questSlot = quest.getSlotName();
+
+		player = PlayerTestHelper.createPlayer("bob");
+
+		baldemar = SingletonRepository.getNPCList().get(NPC_NAME);
+		en = baldemar.getEngine();
 	}
 
-	/**
-	 * Tests for step1.
-	 * 
-	 * @throws Exception if setup failed 
-	 */
-	@Test
-	public void teststep1() throws Exception {
-		QuestHelper.setUpBeforeClass();
-		
-		Engine en = baldemar.getEngine();
-		Player bob = PlayerTestHelper.createPlayer("bob");
+	@Override
+	@After
+	public void tearDown() {
+		PlayerTestHelper.removeNPC(NPC_NAME);
+	}
 
+	@Test
+	public void testAcceptQuest() {
 		en.setCurrentState(ConversationStates.QUEST_OFFERED);
-		en.step(bob, "yes");
+		en.step(player, "yes");
 		assertEquals("I will need many, many things: 20 mithril bars, 1 obsidian, 1 diamond, 5 emeralds,10 carbuncles, 10 sapphires, 1 black shield, 1 magic plate shield, 10 gold bars, 20 iron bars, 10 black pearls, 20 shuriken, 15 marbles and 1 snowglobe. Come back when you have them in the same #exact order!", getReply(baldemar));
 		
-		en.step(bob, "exact");
+		en.step(player, "exact");
 		assertEquals("As I have listed them here, you must provide them in that order.", getReply(baldemar));
-		assertEquals("start;0;0;0;0;0;0;0;0;0;0;0;0;0;0", bob.getQuest(sfb.getSlotName()));
-		
+		assertEquals("start;0;0;0;0;0;0;0;0;0;0;0;0;0;0", player.getQuest(questSlot));
+	}
+
+	@Test
+	public void testBroughtNotEnoughMithrilBars() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;5;0;0;0;0;0;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;5;0;0;0;0;0;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I cannot #forge it without the missing 15 mithril bars. After all, this IS a mithril shield.", getReply(baldemar));
-		
+	}
+
+	@Test
+	public void testBroughtEnoughMithrilBars() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;0;0;0;0;0;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;20;0;0;0;0;0;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need several gems to grind into dust to mix with the mithril. I need an obsidian still.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtObsidian() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;0;0;0;0;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;20;1;0;0;0;0;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need several gems to grind into dust to mix with the mithril. I need a diamond still.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtDiamondAndNotEnoughEmeralds() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;1;0;0;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;20;1;1;1;0;0;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need several gems to grind into dust to mix with the mithril. I need 4 emeralds still.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtEmeraldsAndNotEnoughCarbuncles() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;1;0;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;20;1;1;5;1;0;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need several gems to grind into dust to mix with the mithril. I need 9 carbuncles still.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtCarbunclesAndNotEnoughSapphires() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;1;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;20;1;1;5;10;1;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need several gems to grind into dust to mix with the mithril. I need 9 sapphires still.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtSapphires() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;0;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
-		
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;0;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need a black shield to form the framework for your new shield.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtBlackShield() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;0;0;0;0;0;0;0");
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;0;0;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need a magic plate shield for the pieces and parts for your new shield.", getReply(baldemar));
-	
+	}
+
+	@Test
+	public void testBroughtMagicPlateShield() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;1;0;0;0;0;0");
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;1;0;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need 9 gold bars to melt down with the mithril and iron.", getReply(baldemar));
-	
-		
+	}
+
+	@Test
+	public void testBroughtGoldBarsAndNotEnoughIron() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;10;1;0;0;0;0");
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;1;0;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need 19 pieces of iron to melt down with the mithril and gold.", getReply(baldemar));
-		
+	}
+
+	@Test
+	public void testBroughtIronBarsAndNotEnoughPearls() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;10;20;1;0;0;0");
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;1;0;0;0");
+		en.step(player, "hi");
 		assertEquals("I need 9 black pearls to crush into fine powder to sprinkle onto shield to give it a nice sheen.", getReply(baldemar));
-		
+	}
+
+	@Test
+	public void testBroughtBlackPearlsAndNotEnoughShurikens() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;10;20;10;1;0;0");
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;1;0;0");
+		en.step(player, "hi");
 		assertEquals("I need 19 shurikens to melt down with the mithril, gold and iron. It is a 'secret' ingredient that only you and I know about. ;)", getReply(baldemar));
-		
+	}
+
+	@Test
+	public void testBroughtShurikensAndNotEnoughMarbles() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;10;20;10;20;2;0"); 
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;2;0");
+		en.step(player, "hi");
 		assertEquals("My son wants some new toys. I need 13 marbles still.", getReply(baldemar));
-		
+	}
+
+	@Test
+	public void testBroughtMarbles() {
 		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;10;20;10;20;15;0"); 
-		en.step(bob, "hi");
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;15;0");
+		en.step(player, "hi");
 		assertEquals("I just LOVE those trinkets from athor. I need a snowglobe still.", getReply(baldemar));
-		
-		en.setCurrentState(ConversationStates.IDLE);
-		bob.setQuest(sfb.getSlotName(), "start;20;1;1;5;10;10;1;1;10;20;10;20;15;1"); 
-		en.step(bob, "hi");
-		assertEquals("This shield can only be given to those who have killed a black giant, and without the help of others.", getReply(baldemar));
-		
-		
-		
 	}
 
-
-	/**
-	 * Tests for items.
-	 */
-@Test
-	public void testItems() {
-		Engine en = baldemar.getEngine();
+	@Test
+	public void testBroughtSnowglobe() {
 		en.setCurrentState(ConversationStates.IDLE);
-		Player jim = PlayerTestHelper.createPlayer("jim");
-		
-		jim.setQuest(sfb.getSlotName(), "start;0;0;0;0;0;0;0;0;0;0;0;0;0;0"); 
-		
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "mithril bar", 20));
-		assertTrue(PlayerTestHelper.equipWithItem(jim, "obsidian"));
-		assertTrue(PlayerTestHelper.equipWithItem(jim, "diamond"));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "emerald", 5));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "carbuncle", 10));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "sapphire", 10));
-		assertTrue(PlayerTestHelper.equipWithItem(jim, "black shield"));
-		
-		assertTrue(en.step(jim, "hi"));
-		assertEquals("I need a magic plate shield for the pieces and parts for your new shield.", getReply(baldemar));
-		assertTrue(PlayerTestHelper.equipWithItem(jim, "magic plate shield"));
-		assertTrue(jim.isEquipped("magic plate shield"));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "gold bar", 10));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "iron", 20));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "black pearl", 10));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "shuriken", 20));
-		assertTrue(PlayerTestHelper.equipWithStackableItem(jim, "marbles", 15));
-		assertTrue(PlayerTestHelper.equipWithItem(jim, "snowglobe"));
-		
-		en.setCurrentState(ConversationStates.IDLE);
-		en.step(jim, "hi");
-		
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;15;1");
+		en.step(player, "hi");
 		assertEquals("This shield can only be given to those who have killed a black giant, and without the help of others.", getReply(baldemar));
 	}
+
+	@Test
+	public void testItemsAllUpToBlackShield() {
+		player.setQuest(questSlot, "start;0;0;0;0;0;0;0;0;0;0;0;0;0;0");
+
+		PlayerTestHelper.equipWithStackableItem(player, "mithril bar", 20);
+		PlayerTestHelper.equipWithItem(player, "obsidian");
+		PlayerTestHelper.equipWithItem(player, "diamond");
+		PlayerTestHelper.equipWithStackableItem(player, "emerald", 5);
+		PlayerTestHelper.equipWithStackableItem(player, "carbuncle", 10);
+		PlayerTestHelper.equipWithStackableItem(player, "sapphire", 10);
+		PlayerTestHelper.equipWithItem(player, "black shield");
+
+		en.setCurrentState(ConversationStates.IDLE);
+		en.step(player, "hi");
+
+		assertEquals("start;20;1;1;5;10;10;1;0;0;0;0;0;0;0", player.getQuest(questSlot));
+	}
+
+	@Test
+	public void testItemsAllAfterBlackShield() {
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;0;0;0;0;0;0;0");
+
+		PlayerTestHelper.equipWithItem(player, "magic plate shield");
+		PlayerTestHelper.equipWithStackableItem(player, "gold bar", 10);
+		PlayerTestHelper.equipWithStackableItem(player, "iron", 20);
+		PlayerTestHelper.equipWithStackableItem(player, "black pearl", 10);
+		PlayerTestHelper.equipWithStackableItem(player, "shuriken", 20);
+		PlayerTestHelper.equipWithStackableItem(player, "marbles", 15);
+		PlayerTestHelper.equipWithItem(player, "snowglobe");
+
+		en.setCurrentState(ConversationStates.IDLE);
+		en.step(player, "hi");
+
+		assertEquals("start;20;1;1;5;10;10;1;1;10;20;10;20;15;1", player.getQuest(questSlot));
+	}
+
 	/**
 	 * Tests for itemData.
 	 */
@@ -204,17 +252,28 @@ public class StuffForBaldemarTest {
 		int needed = 20;
 		ItemData id = new ItemData("name", needed, "prefix ", " suffix");
 		assertEquals(needed, id.getStillNeeded());
+
 		id.setAmount(15);
 		assertEquals(15, id.getStillNeeded());
 		assertEquals(needed, id.getRequired());
 		assertEquals("name", id.getName());
 		assertEquals("prefix ", id.getPrefix());
 		assertEquals(" suffix", id.getSuffix());
+
 		id.subAmount("10");
 		assertEquals(5, id.getStillNeeded());
 		assertEquals(needed, id.getRequired());
 		assertEquals(15, id.getAlreadyBrought());
 		assertEquals("prefix 5 names suffix", id.getAnswer());
-		
+	}
+
+	@Test
+	public void testAskToForgeWithoutAllItems() {
+		Engine en = baldemar.getEngine();
+
+		en.setCurrentState(ConversationStates.ATTENDING);
+		player.setQuest(questSlot, "start;20;1;1;5;10;10;1;1;10;20;10;20;12;0");
+		en.step(player, "forge");
+		assertEquals("I will need 0 mithril bars, 0 obsidian, 0 diamond, 0 emeralds, 0 carbuncles, 0 sapphires, 0 black shield, 0 magic plate shield, 0 gold bars, 0 iron bars, 0 black pearls, 0 shuriken, 3 marbles and 1 snowglobe", getReply(baldemar));
 	}
 }

--- a/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
@@ -141,6 +141,30 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 	}
 
 	@Test
+	public void testNeedTwoMoreIronBars() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;13;0;0;0");
+
+		en.step(player, "hi");
+		assertEquals("I cannot #forge it without the missing 2 pieces of iron.", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 2 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testNeedOneMoreIronBar() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;14;0;0;0");
+
+		en.step(player, "hi");
+		assertEquals("I cannot #forge it without the missing a piece of iron.", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 1 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
+
+	@Test
 	public void testBroughtGoldButNotEnoughIronBars() {
 		en.setCurrentState(ConversationStates.IDLE);
 		player.setQuest(questSlot, "start;10;0;0;0");
@@ -185,6 +209,54 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 	}
 
 	@Test
+	public void testNeedTwoMoreWood() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;24;0;0");
+
+		en.step(player, "hi");
+		assertEquals("How do you expect me to #forge it without missing 2 wood logs for the fire?", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 0 #iron, 2 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testNeedOneMoreWood() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;25;0;0");
+
+		en.step(player, "hi");
+		assertEquals("How do you expect me to #forge it without missing a wood log for the fire?", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 0 #iron, 1 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testNeedTwoMoreGoldBars() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;26;10;0");
+
+		en.step(player, "hi");
+		assertEquals("I must pay a bill to spirits in order to cast the enchantment over the sword. I need 2 gold bars more.", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 0 #iron, 0 #wood logs, 2 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testNeedOneMoreGoldBar() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;26;11;0");
+
+		en.step(player, "hi");
+		assertEquals("I must pay a bill to spirits in order to cast the enchantment over the sword. I need one gold bar more.", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 0 #iron, 0 #wood logs, 1 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
+
+	@Test
 	public void testBrought2GiantHearts() {
 		en.setCurrentState(ConversationStates.IDLE);
 		player.setQuest(questSlot, "start;15;26;12;0");
@@ -192,6 +264,18 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
 		en.step(player, "hi");
 		assertEquals("It is the base element of the enchantment. I need 4 giant hearts still.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testNeedOneMoreGiantHeart() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;26;12;5");
+
+		en.step(player, "hi");
+		assertEquals("It is the base element of the enchantment. I need one giant heart still.", getReply(vulcanus));
+
+		en.step(player, "forge");
+		assertEquals("I will need 0 #iron, 0 #wood logs, 0 #gold bars and 1 #giant hearts.", getReply(vulcanus));
 	}
 
 	@Test

--- a/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
@@ -12,184 +12,245 @@
  ***************************************************************************/
 package games.stendhal.server.maps.quests;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static utilities.SpeakerNPCTestHelper.getReply;
-import games.stendhal.server.core.config.ZoneConfigurator;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
 import games.stendhal.server.core.engine.SingletonRepository;
 import games.stendhal.server.core.engine.StendhalRPZone;
-import games.stendhal.server.entity.item.Item;
 import games.stendhal.server.entity.npc.ConversationStates;
 import games.stendhal.server.entity.npc.SpeakerNPC;
 import games.stendhal.server.entity.npc.fsm.Engine;
 import games.stendhal.server.entity.player.Player;
 import games.stendhal.server.maps.kotoch.SmithNPC;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import utilities.PlayerTestHelper;
 import utilities.QuestHelper;
-import utilities.RPClass.ItemTestHelper;
+import utilities.ZonePlayerAndNPCTestImpl;
 
-public class StuffForVulcanusTest {
+public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
-	private Player player = null;
-	private SpeakerNPC npc = null;
-	private Engine en = null;
+	private static final String ZONE_NAME = "-1_kotoch_entrance_n";
+	private static final String NPC_NAME = "Vulcanus";
+
+	private static final String HISTORY_DEFAULT = "I met Vulcanus in Kotoch.";
+	private static final String HISTORY_REJECTED = "I don't want an immortal sword.";
+
+	private Player player;
+	private SpeakerNPC vulcanus;
+	private Engine en;
+
+	private StuffForVulcanus quest;
+	private String questSlot;
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		QuestHelper.setUpBeforeClass();
+		setupZone(ZONE_NAME);
 	}
 
+	public StuffForVulcanusTest() {
+		super(ZONE_NAME, NPC_NAME);
+	}
+
+	@Override
 	@Before
 	public void setUp() {
-		final ZoneConfigurator zoneConf = new SmithNPC();
-		zoneConf.configureZone(new StendhalRPZone("admin_test"), null);
-		npc = SingletonRepository.getNPCList().get("Vulcanus");
+		final StendhalRPZone zone = new StendhalRPZone(ZONE_NAME);
+		new SmithNPC().configureZone(zone, null);
 
-		final AbstractQuest quest = new StuffForVulcanus();
+		quest = new StuffForVulcanus();
 		quest.addToWorld();
-		en = npc.getEngine();
 
-		player = PlayerTestHelper.createPlayer("player");
+		questSlot = quest.getSlotName();
+
+		player = PlayerTestHelper.createPlayer("bob");
+
+		vulcanus = SingletonRepository.getNPCList().get(NPC_NAME);
+		en = vulcanus.getEngine();
 	}
 
-	/**
-	 * Tests for hiAndByeQuest.
-	 */
+	@Override
+	@After
+	public void tearDown() {
+		PlayerTestHelper.removeNPC(NPC_NAME);
+	}
+
 	@Test
-	public void testHiAndByeQuest() {
+	public void testTalkGreeting() {
 		assertTrue(en.step(player, "hi"));
-		assertEquals("Chairetismata! I am Vulcanus the smither.", getReply(npc));
+		assertEquals("Chairetismata! I am Vulcanus the smither.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testTalkHelp() {
+		en.step(player, "hi");
+
 		assertTrue(en.step(player, "help"));
-		assertEquals("I may help you to get a very #special item for only a few others...", getReply(npc));
+		assertEquals("I may help you to get a very #special item for only a few others...", getReply(vulcanus));
+
 		assertTrue(en.step(player, "special"));
-		assertEquals("Who told you that!?! *cough* Anyway, yes, I can forge a very special item for you. But you will need to complete a #quest", getReply(npc));
+		assertEquals("Who told you that!?! *cough* Anyway, yes, I can forge a very special item for you. But you will need to complete a #quest", getReply(vulcanus));
 		assertFalse(en.step(player, "yes"));
-		assertTrue(en.step(player, "quest"));
-		assertEquals("I once forged the most powerful of swords. I can do it again for you. Are you interested?", getReply(npc));
-		assertTrue(en.step(player, "no"));
-		assertEquals("Oh, well forget it then, if you don't want an immortal sword...", getReply(npc));
+	}
+
+	@Test
+	public void testRejectQuest() {
+		en.setCurrentState(ConversationStates.QUEST_OFFERED);
+		en.step(player, "no");
+
+		assertEquals("Oh, well forget it then, if you don't want an immortal sword...", getReply(vulcanus));
 		assertEquals(ConversationStates.IDLE, en.getCurrentState());
-		assertEquals("rejected", player.getQuest("immortalsword_quest"));
-		// -----------------------------------------------
+		assertEquals("rejected", player.getQuest(questSlot));
+		assertHistory(HISTORY_DEFAULT, HISTORY_REJECTED);
+	}
 
-		en.step(player, "hi");
-		assertEquals("Chairetismata! I am Vulcanus the smither.", getReply(npc));
-		en.step(player, "task");
-		assertEquals("I once forged the most powerful of swords. I can do it again for you. Are you interested?", getReply(npc));
+	@Test
+	public void testAcceptQuest() {
+		String neededItems = "15 iron, 26 wood logs, 12 gold bars and 6 giant hearts";
+
+		en.setCurrentState(ConversationStates.QUEST_OFFERED);
 		en.step(player, "yes");
-		assertEquals("I will need several things: 15 iron, 26 wood logs, 12 gold bars and 6 giant hearts. Come back when you have them in the same #exact order!", getReply(npc));
+		assertEquals("I will need several things: " + neededItems + ". Come back when you have them in the same #exact order!", getReply(vulcanus));
+
 		en.step(player, "exact");
-		assertEquals("This archaic magic requires that the ingredients are added on an exact order.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
+		assertEquals("This archaic magic requires that the ingredients are added on an exact order.", getReply(vulcanus));
+		assertEquals("start;0;0;0;0", player.getQuest(questSlot));
+		//TODO assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_NEED_ITEMS_PREFIX + neededItems + HISTORY_NEED_ITEMS_SUFFIX);
+	}
 
-		// -----------------------------------------------
-
-		// superkym gets 10 iron
-		Item item = ItemTestHelper.createItem("iron", 10);
-		player.getSlot("bag").add(item);
+	@Test
+	public void testBroughtNotEnoughIronBars() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;10;0;0;0");
 
 		en.step(player, "hi");
-		assertEquals("I cannot #forge it without the missing 5 pieces of iron.", getReply(npc));
+		assertEquals("I cannot #forge it without the missing 5 pieces of iron.", getReply(vulcanus));
+
 		en.step(player, "forge");
-		assertEquals("I will need 5 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
+		assertEquals("I will need 5 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+	}
 
-		// -----------------------------------------------
-		// superkym gets 12 gold bar but he wants iron first
-		item = ItemTestHelper.createItem("gold bar", 12);
-		player.getSlot("bag").add(item);
-
-		en.step(player, "hi");
-		assertEquals("I cannot #forge it without the missing 5 pieces of iron.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
-
-		// -----------------------------------------------
-		// superkym gets 10 iron, still has that gold in bag too
-		item = ItemTestHelper.createItem("iron", 10);
-		player.getSlot("bag").add(item);
+	@Test
+	public void testBroughtGoldButNotEnoughIronBars() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;10;0;0;0");
+		PlayerTestHelper.equipWithStackableItem(player, "gold bar", 12);
 
 		en.step(player, "hi");
-		assertEquals("How do you expect me to #forge it without missing 26 wood logs for the fire?", getReply(npc));
+		assertEquals("I cannot #forge it without the missing 5 pieces of iron.", getReply(vulcanus));
+
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
+		assertEquals("I will need 5 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
 
-		// -----------------------------------------------
-		// superkym gets the 26 wood and he takes the 12 gold bar at same time too
-		item = ItemTestHelper.createItem("wood", 26);
-		player.getSlot("bag").add(item);
+		assertTrue(player.isEquipped("gold bar", 12));
+	}
 
-		en.step(player, "hi");
-		assertEquals("It is the base element of the enchantment. I need 6 giant hearts still.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
-
-		// -----------------------------------------------
-
-		// superkym gets 2 hearts
-		item = ItemTestHelper.createItem("giant heart", 2);
-		player.getSlot("bag").add(item);
+	@Test
+	public void testBroughtRemainingIronAndGold() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;10;0;0;0");
+		PlayerTestHelper.equipWithStackableItem(player, "gold bar", 12);
+		PlayerTestHelper.equipWithStackableItem(player, "iron", 10);
 
 		en.step(player, "hi");
-		assertEquals("It is the base element of the enchantment. I need 4 giant hearts still.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
+		assertEquals("How do you expect me to #forge it without missing 26 wood logs for the fire?", getReply(vulcanus));
 
-		// -----------------------------------------------
-		// superkym gets remaining 4 hearts
-		item = ItemTestHelper.createItem("giant heart", 4);
-		player.getSlot("bag").add(item);
+		en.step(player, "forge");
+		assertEquals("I will need 0 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+
+		assertTrue(player.isEquipped("gold bar", 12));
+	}
+
+	@Test
+	public void testBroughtWoodAndGold() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;0;0;0");
+		PlayerTestHelper.equipWithStackableItem(player, "gold bar", 12);
+		PlayerTestHelper.equipWithStackableItem(player, "wood", 26);
 
 		en.step(player, "hi");
-		assertEquals("Did you really get those giant hearts yourself? I don't think so! This powerful sword can only be given to those that are strong enough to kill a #giant.", getReply(npc));
+		assertEquals("It is the base element of the enchantment. I need 6 giant hearts still.", getReply(vulcanus));
+
+		assertFalse(player.isEquipped("gold bar"));
+	}
+
+	@Test
+	public void testBrought2GiantHearts() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;26;12;0");
+		PlayerTestHelper.equipWithStackableItem(player, "giant heart", 2);
+
+		en.step(player, "hi");
+		assertEquals("It is the base element of the enchantment. I need 4 giant hearts still.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testBroughtRemainingGiantHearts() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;26;12;2");
+		PlayerTestHelper.equipWithStackableItem(player, "giant heart", 4);
+
+		en.step(player, "hi");
+		assertEquals("Did you really get those giant hearts yourself? I don't think so! This powerful sword can only be given to those that are strong enough to kill a #giant.", getReply(vulcanus));
 		en.step(player, "giant");
-		assertEquals("There are ancient stories of giants living in the mountains at the north of Semos and Ados.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
+		assertEquals("There are ancient stories of giants living in the mountains at the north of Semos and Ados.", getReply(vulcanus));
 
-		// -----------------------------------------------
-		// superkym summons a giant and kills it, it nearly kills her first!
-		// [23:14] superkym earns 14400 experience points. 
-		// [23:14] superkym reaches Level 20 
-		// [23:15] You see the new corpse of a giant human. You can inspect it to see its contents
+		assertFalse(player.isEquipped("giant heart"));
+	}
+
+	@Test
+	public void testBroughtEverythingAndKilledGiant() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "start;15;26;12;6");
 		player.setSharedKill("giant");
 
 		en.step(player, "hi");
-		assertEquals("You've brought everything I need to make the immortal sword, and what is more, you are strong enough to handle it. Come back in 10 minutes and it will be ready.", getReply(npc));
-		en.step(player, "bye");
-		assertEquals("Farewell", getReply(npc));
 
-		// -----------------------------------------------
-		
-		
+		assertEquals("You've brought everything I need to make the immortal sword, and what is more, you are strong enough to handle it. Come back in 10 minutes and it will be ready.", getReply(vulcanus));
+	}
+
+	@Test
+	public void testForgingNotComplete() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "forging;" + (System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5)));
+
 		en.step(player, "hi");
-		assertEquals("I haven't finished forging the sword. Please check back in 10 minutes.", getReply(npc));
-		en.step(player, "bye");
-		
-		// -----------------------------------------------
-		
-		player.setQuest("immortalsword_quest", "forging;0");
+
+		assertTrue(getReply(vulcanus).startsWith("I haven't finished forging the sword. Please check back in"));
+	}
+
+	@Test
+	public void testForgingComplete() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "forging;" + (System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(20)));
+
 		en.step(player, "hi");
-		assertEquals("I have finished forging the mighty immortal sword. You deserve this. Now I'm going to have a long rest, so, goodbye!", getReply(npc));
-		// [23:26] superkym earns 15000 experience points.
+
+		assertTrue(getReply(vulcanus).startsWith("I have finished forging the mighty immortal sword. You deserve this."));
+		assertEquals("done", player.getQuest(questSlot));
+	}
+
+	@Test
+	public void testAttemptToRepeatTask() {
+		en.setCurrentState(ConversationStates.IDLE);
+		player.setQuest(questSlot, "done");
+
+		en.step(player, "hi");
 		en.step(player, "task");
+		assertEquals("Oh! I am so tired. Look for me later. I need a few years of relaxing.", getReply(vulcanus));
+	}
 
-		// -----------------------------------------------
-
-		en.step(player, "hi");
-		assertEquals("Chairetismata! I am Vulcanus the smither.", getReply(npc));
-		en.step(player, "task");
-		assertEquals("Oh! I am so tired. Look for me later. I need a few years of relaxing.", getReply(npc));
-		
+	private void assertHistory(String... entries) {
+		assertEquals(Arrays.asList(entries), quest.getHistory(player));
 	}
 }

--- a/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
@@ -44,6 +44,14 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
 	private static final String HISTORY_DEFAULT = "I met Vulcanus in Kotoch.";
 	private static final String HISTORY_REJECTED = "I don't want an immortal sword.";
+	private static final String HISTORY_START = "To forge the immortal sword I must bring several things to Vulcanus.";
+	private static final String HISTORY_NEED_ITEMS_PREFIX = "I still need to bring ";
+	private static final String HISTORY_NEED_ITEMS_SUFFIX = ", in this order.";
+	private static final String HISTORY_NEED_ONE_ITEM_SUFFIX = ".";
+	private static final String HISTORY_BROUGHT_ALL_ITEMS = "I took all the special items to Vulcanus.";
+	private static final String HISTORY_NEED_KILL_GIANT = "I must prove my worth and kill a giant, before I am worthy of this prize.";
+	private static final String HISTORY_REWARD_PENDING = "Vulcanus, son of gods himself, now forges my immortal sword.";
+	private static final String HISTORY_COMPLETED = "Gold bars and giant hearts together with the forging from a god's son made me a sword of which I can be proud.";
 
 	private Player player;
 	private SpeakerNPC vulcanus;
@@ -125,7 +133,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		en.step(player, "exact");
 		assertEquals("This archaic magic requires that the ingredients are added on an exact order.", getReply(vulcanus));
 		assertEquals("start;0;0;0;0", player.getQuest(questSlot));
-		//TODO assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_NEED_ITEMS_PREFIX + neededItems + HISTORY_NEED_ITEMS_SUFFIX);
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_NEED_ITEMS_PREFIX + neededItems + HISTORY_NEED_ITEMS_SUFFIX);
 	}
 
 	@Test
@@ -138,6 +146,9 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
 		en.step(player, "forge");
 		assertEquals("I will need 5 #'pieces of iron', 26 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
+
+		String neededItems = "5 pieces of iron, 26 pieces of wood, 12 gold bars and 6 giant hearts";
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_NEED_ITEMS_PREFIX + neededItems + HISTORY_NEED_ITEMS_SUFFIX);
 	}
 
 	@Test
@@ -276,6 +287,9 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
 		en.step(player, "forge");
 		assertEquals("I will need a #'giant heart'.", getReply(vulcanus));
+
+		String neededItems = "a giant heart";
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_NEED_ITEMS_PREFIX + neededItems + HISTORY_NEED_ONE_ITEM_SUFFIX);
 	}
 
 	@Test
@@ -290,6 +304,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals("There are ancient stories of giants living in the mountains at the north of Semos and Ados.", getReply(vulcanus));
 
 		assertFalse(player.isEquipped("giant heart"));
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_BROUGHT_ALL_ITEMS, HISTORY_NEED_KILL_GIANT);
 	}
 
 	@Test
@@ -301,6 +316,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		en.step(player, "hi");
 
 		assertEquals("You've brought everything I need to make the immortal sword, and what is more, you are strong enough to handle it. Come back in 10 minutes and it will be ready.", getReply(vulcanus));
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_BROUGHT_ALL_ITEMS, HISTORY_REWARD_PENDING);
 	}
 
 	@Test
@@ -311,6 +327,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		en.step(player, "hi");
 
 		assertTrue(getReply(vulcanus).startsWith("I haven't finished forging the sword. Please check back in"));
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_BROUGHT_ALL_ITEMS, HISTORY_REWARD_PENDING);
 	}
 
 	@Test
@@ -322,6 +339,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
 		assertTrue(getReply(vulcanus).startsWith("I have finished forging the mighty immortal sword. You deserve this."));
 		assertEquals("done", player.getQuest(questSlot));
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_BROUGHT_ALL_ITEMS, HISTORY_COMPLETED);
 	}
 
 	@Test

--- a/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
+++ b/tests/games/stendhal/server/maps/quests/StuffForVulcanusTest.java
@@ -116,7 +116,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 
 	@Test
 	public void testAcceptQuest() {
-		String neededItems = "15 iron, 26 wood logs, 12 gold bars and 6 giant hearts";
+		String neededItems = "15 pieces of iron, 26 pieces of wood, 12 gold bars and 6 giant hearts";
 
 		en.setCurrentState(ConversationStates.QUEST_OFFERED);
 		en.step(player, "yes");
@@ -137,7 +137,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals("I cannot #forge it without the missing 5 pieces of iron.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 5 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need 5 #'pieces of iron', 26 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals("I cannot #forge it without the missing 2 pieces of iron.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 2 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need 2 #'pieces of iron', 26 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -161,7 +161,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals("I cannot #forge it without the missing a piece of iron.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 1 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need a #'piece of iron', 26 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -174,7 +174,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals("I cannot #forge it without the missing 5 pieces of iron.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 5 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need 5 #'pieces of iron', 26 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 
 		assertTrue(player.isEquipped("gold bar", 12));
 	}
@@ -187,10 +187,10 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		PlayerTestHelper.equipWithStackableItem(player, "iron", 10);
 
 		en.step(player, "hi");
-		assertEquals("How do you expect me to #forge it without missing 26 wood logs for the fire?", getReply(vulcanus));
+		assertEquals("How do you expect me to #forge it without missing 26 pieces of wood for the fire?", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 26 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need 26 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 
 		assertTrue(player.isEquipped("gold bar", 12));
 	}
@@ -214,10 +214,10 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		player.setQuest(questSlot, "start;15;24;0;0");
 
 		en.step(player, "hi");
-		assertEquals("How do you expect me to #forge it without missing 2 wood logs for the fire?", getReply(vulcanus));
+		assertEquals("How do you expect me to #forge it without missing 2 pieces of wood for the fire?", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 2 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need 2 #'pieces of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -226,10 +226,10 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		player.setQuest(questSlot, "start;15;25;0;0");
 
 		en.step(player, "hi");
-		assertEquals("How do you expect me to #forge it without missing a wood log for the fire?", getReply(vulcanus));
+		assertEquals("How do you expect me to #forge it without missing a piece of wood for the fire?", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 1 #wood logs, 12 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need a #'piece of wood', 12 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -241,7 +241,7 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals("I must pay a bill to spirits in order to cast the enchantment over the sword. I need 2 gold bars more.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 0 #wood logs, 2 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need 2 #'gold bars' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -250,10 +250,10 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		player.setQuest(questSlot, "start;15;26;11;0");
 
 		en.step(player, "hi");
-		assertEquals("I must pay a bill to spirits in order to cast the enchantment over the sword. I need one gold bar more.", getReply(vulcanus));
+		assertEquals("I must pay a bill to spirits in order to cast the enchantment over the sword. I need a gold bar more.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 0 #wood logs, 1 #gold bars and 6 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need a #'gold bar' and 6 #'giant hearts'.", getReply(vulcanus));
 	}
 
 	@Test
@@ -272,10 +272,10 @@ public class StuffForVulcanusTest extends ZonePlayerAndNPCTestImpl {
 		player.setQuest(questSlot, "start;15;26;12;5");
 
 		en.step(player, "hi");
-		assertEquals("It is the base element of the enchantment. I need one giant heart still.", getReply(vulcanus));
+		assertEquals("It is the base element of the enchantment. I need a giant heart still.", getReply(vulcanus));
 
 		en.step(player, "forge");
-		assertEquals("I will need 0 #iron, 0 #wood logs, 0 #gold bars and 1 #giant hearts.", getReply(vulcanus));
+		assertEquals("I will need a #'giant heart'.", getReply(vulcanus));
 	}
 
 	@Test

--- a/tests/games/stendhal/server/maps/quests/logic/ItemCollectorDataTest.java
+++ b/tests/games/stendhal/server/maps/quests/logic/ItemCollectorDataTest.java
@@ -1,0 +1,22 @@
+package games.stendhal.server.maps.quests.logic;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ItemCollectorDataTest {
+
+	@Test
+	public void testSubtractAmount() {
+		int needed = 20;
+		ItemCollectorData id = (ItemCollectorData) new ItemCollectorData().item("name").pieces(needed)
+				.bySaying("prefix %s suffix");
+
+		id.subtractAmount("5");
+
+		assertEquals(15, id.getStillNeeded());
+		assertEquals(needed, id.getRequiredAmount());
+		assertEquals(5, id.getAlreadyBrought());
+		assertEquals("prefix 15 names suffix", id.getAnswer());
+	}
+}


### PR DESCRIPTION
Refactored the "Stuff for Baldemar" and "Stuff for Vulcanus" quests to enable showing in the quest log what items are still needed.
Also reused this to improve the answer to "forge" by not mentioning items already brought (so don't say "I will need 0 mithril bars, 0 obsidian, ..., and a snowglobe").