### PR TITLE
Follow cross protocol redirects in HttpClient (fixes #5846)

### DIFF
--- a/src/games/stendhal/client/update/HttpClient.java
+++ b/src/games/stendhal/client/update/HttpClient.java
@@ -21,10 +21,9 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-
-import com.google.common.collect.Sets;
 
 /**
  * a very simple http client.
@@ -125,7 +124,8 @@ public class HttpClient {
 						// handle redirects
 						if(isRedirect(responseCode)) {
 							boolean redirect = true;
-							Set<String> passedRedirects = Sets.newHashSet(url.toString());
+							Set<String> passedRedirects = new HashSet<String>();
+							passedRedirects.add(urlString);
 							
 							while(redirect) {
 								String newUrl = connection.getHeaderField("Location");

--- a/src/games/stendhal/client/update/HttpClient.java
+++ b/src/games/stendhal/client/update/HttpClient.java
@@ -22,6 +22,9 @@ import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.Properties;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 /**
  * a very simple http client.
@@ -117,12 +120,33 @@ public class HttpClient {
 					connection.setConnectTimeout(myTimeout);
 					connection.setInstanceFollowRedirects(true);
 					connection.setUseCaches(false);
-					if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-						System.err.println("HttpServer returned an error code ("
-								+ urlString
-								+ "): "
-								+ connection.getResponseCode());
-						connection = null;
+					int responseCode = connection.getResponseCode();
+					if (responseCode != HttpURLConnection.HTTP_OK) {
+						// handle redirects
+						if(isRedirect(responseCode)) {
+							boolean redirect = true;
+							Set<String> passedRedirects = Sets.newHashSet(url.toString());
+							
+							while(redirect) {
+								String newUrl = connection.getHeaderField("Location");
+								
+								// check if we already were redirected to this url
+								if(!passedRedirects.contains(newUrl)) {
+									// open the new connnection again
+									passedRedirects.add(newUrl);
+									connection = (HttpURLConnection) new URL(newUrl).openConnection();
+									redirect = isRedirect(connection.getResponseCode());
+								} else {
+									throw new IOException(String.format("The URL '%s' lead to a redirect circle!", url));
+								}
+							}
+						} else {
+							System.err.println("HttpServer returned an error code ("
+									+ urlString
+									+ "): "
+									+ responseCode);
+							connection = null;
+						}
 					}
 					if (connection != null) {
 						is = connection.getInputStream();
@@ -145,6 +169,16 @@ public class HttpClient {
 			e.printStackTrace(System.err);
 		}
 		return;
+	}
+
+	/**
+	 * Determine if a repsonse code is a redirect
+	 * 
+	 * @param responseCode
+	 * @return
+	 */
+	private boolean isRedirect(int responseCode) {
+		return responseCode == HttpURLConnection.HTTP_MOVED_TEMP || responseCode == HttpURLConnection.HTTP_MOVED_PERM || responseCode == HttpURLConnection.HTTP_SEE_OTHER;
 	}
 
 	/**


### PR DESCRIPTION
This fix allows the HttpClient to follow redirects across protocols, e.g. http --> https --> http. It was necessary to implement this due to sourceforge fully rolling out https.

See also this bug at https://sourceforge.net/p/arianne/bugs/5846/