### PR TITLE
Do not throw an exception in case of a circular redirect

### DIFF
--- a/src/games/stendhal/client/update/HttpClient.java
+++ b/src/games/stendhal/client/update/HttpClient.java
@@ -137,7 +137,8 @@ public class HttpClient {
 									connection = (HttpURLConnection) new URL(newUrl).openConnection();
 									redirect = isRedirect(connection.getResponseCode());
 								} else {
-									throw new IOException(String.format("The URL '%s' lead to a redirect circle!", url));
+									System.err.println(String.format("The URL '%s' leads into a circular redirect.", url));
+									connection = null;
 								}
 							}
 						} else {


### PR DESCRIPTION
With pull request #15 following redirects was introduced. On circular redirects the client threw an exception which was inconsistent with other behaviour. Now the circular redirect is just reported.