### PR TITLE
Used tally marks in the KillMonks history.

### DIFF
--- a/src/games/stendhal/server/core/rp/StendhalQuestSystem.java
+++ b/src/games/stendhal/server/core/rp/StendhalQuestSystem.java
@@ -444,7 +444,7 @@ public class StendhalQuestSystem {
 		for (final IQuest quest : quests) {
 			final QuestInfo questInfo = quest.getQuestInfo(player);
 			if (questInfo.getName().equals(questName)) {
-				final List<String> history = quest.getHistory(player);
+				final List<String> history = quest.getFormattedHistory(player);
 				for (final String entry : history) {
 					res.add(entry);
 				}

--- a/src/games/stendhal/server/maps/quests/AbstractQuest.java
+++ b/src/games/stendhal/server/maps/quests/AbstractQuest.java
@@ -91,7 +91,9 @@ public abstract class AbstractQuest implements IQuest {
 	}
 
 	@Override
-	public abstract List<String> getHistory(final Player player);
+	public List<String> getFormattedHistory(final Player player) {
+		return getHistory(player);
+	}
 
 	@Override
 	public boolean isCompleted(final Player player) {

--- a/src/games/stendhal/server/maps/quests/IQuest.java
+++ b/src/games/stendhal/server/maps/quests/IQuest.java
@@ -84,6 +84,8 @@ public interface IQuest {
 	 */
 	List<String> getHistory(Player player);
 
+	List<String> getFormattedHistory(Player player);
+
 	/**
 	 * Gets a list of possible hint-names.
 	 * <p>

--- a/src/games/stendhal/server/maps/quests/KillMonks.java
+++ b/src/games/stendhal/server/maps/quests/KillMonks.java
@@ -42,6 +42,7 @@ import games.stendhal.server.entity.npc.condition.TimePassedCondition;
 import games.stendhal.server.entity.player.Player;
 import games.stendhal.server.maps.Region;
 import games.stendhal.server.util.KillsForQuestCounter;
+import games.stendhal.server.util.TallyMarks;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -207,9 +208,18 @@ public class KillMonks extends AbstractQuest {
 		step_2();
 		step_3();
 	}
-	
+
 	@Override
 	public List<String> getHistory(final Player player) {
+		return getHistory(player, false);
+	}
+
+	@Override
+	public List<String> getFormattedHistory(final Player player) {
+		return getHistory(player, true);
+	}
+
+	private List<String> getHistory(final Player player, boolean formatted) {
 			final List<String> res = new ArrayList<>();
 			if (!player.hasQuest(QUEST_SLOT)) {
 				return res;
@@ -224,7 +234,11 @@ public class KillMonks extends AbstractQuest {
 			}
 			if ("start".equals(questState)) {
 				res.add("I promised to kill 25 monks and 25 darkmonks to get revenge for Andy's wife.");
-				res.add(howManyWereKilled(player, parts[1]));
+				if (formatted) {
+					res.addAll(howManyWereKilledFormatted(player, parts[1]));
+				} else {
+					res.add(howManyWereKilled(player, parts[1]));
+				}
 			}
 			if (isCompleted(player)) {
 				if(isRepeatable(player)){
@@ -243,17 +257,20 @@ public class KillMonks extends AbstractQuest {
 
 	private String howManyWereKilled(final Player player, final String questState) {
 		KillsForQuestCounter killsCounter = new KillsForQuestCounter(questState);
-		int remainingMonks = killsCounter.remainingKills(player, "monk");
-		int remainingDarkMonks = killsCounter.remainingKills(player, "darkmonk");
-		if (remainingMonks > 0 && remainingDarkMonks > 0) {
-			return "I still need to kill " + Grammar.quantityplnoun(remainingMonks, "monk")  + " and " + Grammar.quantityplnoun(remainingDarkMonks, "darkmonk") + ".";
-		} else if (remainingMonks > 0) {
-			return "I still need to kill " + Grammar.quantityplnoun(remainingMonks, "monk") + ".";
-		} else if (remainingDarkMonks > 0) {
-			return "I still need to kill " + Grammar.quantityplnoun(remainingDarkMonks, "darkmonk") + ".";
-		} else {
-			return "I have killed 25 monks and 25 darkmonks.";
-		}
+		int killedMonks = 25 - killsCounter.remainingKills(player, "monk");
+		int killedDarkMonks = 25 - killsCounter.remainingKills(player, "darkmonk");
+		return "I have killed " + Grammar.quantityplnoun(killedMonks, "monk") + " and " + Grammar.quantityplnoun(killedDarkMonks, "darkmonk") + ".";
+	}
+
+	private List<String> howManyWereKilledFormatted(final Player player, final String questState) {
+		KillsForQuestCounter killsCounter = new KillsForQuestCounter(questState);
+		int killedMonks = 25 - killsCounter.remainingKills(player, "monk");
+		int killedDarkMonks = 25 - killsCounter.remainingKills(player, "darkmonk");
+
+		List<String> entries = new ArrayList<>();
+		entries.add("Monks: <span style=\"font-family: 'Tally'\">" + new TallyMarks(killedMonks) + "</span>");
+		entries.add("Darkmonks: <span style=\"font-family: 'Tally'\">" + new TallyMarks(killedDarkMonks) + "</span>");
+		return entries;
 	}
 
 	@Override

--- a/src/games/stendhal/server/util/TallyMarks.java
+++ b/src/games/stendhal/server/util/TallyMarks.java
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *                   (C) Copyright 2003-2016 - Stendhal                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+package games.stendhal.server.util;
+
+/**
+ * Tally marks representation of an integer number. The number is split into
+ * groups of fives. For example, 12 is transformed into 552 (12 = 5+5+2).
+ */
+public class TallyMarks {
+
+	private final int value;
+
+	public TallyMarks(int value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		if (value < 0) {
+			return "0";
+		}
+		int quotient = value / 5;
+		int remainder = value % 5;
+		StringBuilder digits = new StringBuilder();
+		for (int i = 0; i < quotient; i++) {
+			digits.append("5");
+		}
+		if ((quotient > 0 && remainder > 0) || quotient == 0) {
+			digits.append(String.valueOf(remainder));
+		}
+		return digits.toString();
+	}
+}

--- a/tests/games/stendhal/server/maps/quests/KillMonksTest.java
+++ b/tests/games/stendhal/server/maps/quests/KillMonksTest.java
@@ -48,7 +48,7 @@ public class KillMonksTest extends ZonePlayerAndNPCTestImpl {
 	private static final String HISTORY_DEFAULT = "I met Andy in Ados city. He asked me to get revenge for his wife.";
 	private static final String HISTORY_REJECTED = "I rejected his request.";
 	private static final String HISTORY_START = "I promised to kill 25 monks and 25 darkmonks to get revenge for Andy's wife.";
-	private static final String HISTORY_STATUS = "I still need to kill ";
+	private static final String HISTORY_STATUS = "I have killed ";
 	private static final String HISTORY_COMPLETED_REPEATABLE = "Now, after more than two weeks, I should check on Andy again. Maybe he needs my help!";
 	private static final String HISTORY_COMPLETED_NOT_REPEATABLE = "I've killed some monks and Andy finally can sleep a bit better!";
 	private static final String HISTORY_COMPLETED_ONCE = "I have taken revenge for Andy 1 time now.";
@@ -111,7 +111,7 @@ public class KillMonksTest extends ZonePlayerAndNPCTestImpl {
 
 		assertEquals("start", player.getQuest(questSlot, 0));
 		assertGainKarma(5);
-		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_STATUS + "25 monks and 25 darkmonks.");
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_STATUS + "0 monks and 0 darkmonks.");
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class KillMonksTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals(NPC_TALK_QUEST_REMIND, getReply(npc));
 
 		assertEquals(QUEST_STATE_JUST_STARTED, player.getQuest(questSlot));
-		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_STATUS + "24 monks and 23 darkmonks.");
+		assertHistory(HISTORY_DEFAULT, HISTORY_START, HISTORY_STATUS + "1 monk and 2 darkmonks.");
 	}
 
 	@Test

--- a/tests/games/stendhal/server/util/TallyMarksTest.java
+++ b/tests/games/stendhal/server/util/TallyMarksTest.java
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *                   (C) Copyright 2003-2016 - Stendhal                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+package games.stendhal.server.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TallyMarksTest {
+
+	@Test
+	public void testNegative() {
+		assertEquals("0", new TallyMarks(-1).toString());
+	}
+
+	@Test
+	public void testZero() {
+		assertEquals("0", new TallyMarks(0).toString());
+	}
+
+	@Test
+	public void testOne() {
+		assertEquals("1", new TallyMarks(1).toString());
+	}
+
+	@Test
+	public void testFour() {
+		assertEquals("4", new TallyMarks(4).toString());
+	}
+
+	@Test
+	public void testFive() {
+		assertEquals("5", new TallyMarks(5).toString());
+	}
+
+	@Test
+	public void testSix() {
+		assertEquals("51", new TallyMarks(6).toString());
+	}
+
+	@Test
+	public void testTen() {
+		assertEquals("55", new TallyMarks(10).toString());
+	}
+
+	@Test
+	public void testTwelve() {
+		assertEquals("552", new TallyMarks(12).toString());
+	}
+}


### PR DESCRIPTION
Used tally marks in the KillMonks history.
Keep displaying as plain-text for the output of the `/listquests` command.
![screenshot](https://ibin.co/2uLZZRsORify.png)