### PR TITLE
Pathfinder limits are outdated

### DIFF
--- a/src/games/stendhal/server/core/pathfinder/Path.java
+++ b/src/games/stendhal/server/core/pathfinder/Path.java
@@ -44,7 +44,7 @@ public abstract class Path {
 		 * so don't allow arbitrary length searches.
 		 */
 		int manhattan = Math.abs(x - entity.getX()) + Math.abs(y - entity.getY());
-		return Math.max(2 * manhattan, 40);
+		return Math.max(4 * manhattan, 80);
 	}
 
 	//


### PR DESCRIPTION
The current pathfinder limit fails at finding a path from Semos bank entry to any chest. The performance of modern computers has increased a lot since the introduction of this arbitrarily small limit.