### PR TITLE
Stat for Range Attacks Independent of Melee Attack Stat

### DIFF
--- a/data/conf/items/arrows.xml
+++ b/data/conf/items/arrows.xml
@@ -6,7 +6,7 @@
     <description>You see a wooden arrow. With a supply of arrows in one hand and a bow in the other you can attack from a distance.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="1"/>
+      <ratk value="1"/>
       <range value="2"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -28,7 +28,7 @@
     <description>You see a shining steel arrow. With plenty of these, and a good bow, you'll be a formidable archer.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="3"/>
+      <ratk value="3"/>
       <range value="2"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -50,7 +50,7 @@
     <description>You see a golden arrow.  With a fist full of these and a good bow, you will surely take down your enemies quicker.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="4"/>
+      <ratk value="4"/>
       <range value="3"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -72,7 +72,7 @@
     <description>You see a fire arrow. The tip burns brightly.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="6"/>
+      <ratk value="6"/>
       <range value="4"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -95,7 +95,7 @@
     <description>You see an ice arrow. It can deliver a bitter sting.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="6"/>
+      <ratk value="6"/>
       <range value="4"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -118,7 +118,7 @@
     <description>You see a light arrow. It shines with a holy radiance.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="6"/>
+      <ratk value="6"/>
       <range value="4"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -141,7 +141,7 @@
     <description>You see a dark arrow. It's hard to describe.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="6"/>
+      <ratk value="6"/>
       <range value="4"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -164,7 +164,7 @@
     <description>You see a power arrow.  The sting of this arrow will surely defeat your enemies, when equipped with a bow.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="6"/>
+      <ratk value="6"/>
       <range value="4"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>

--- a/data/conf/items/missiles.xml
+++ b/data/conf/items/missiles.xml
@@ -7,7 +7,7 @@
     <description>You see snowballs. You can throw them at your friends or put it in your bag to keep your fish fresh. But be careful, there could be little stones in it.</description>
     <implementation class-name="games.stendhal.server.entity.item.NoStatsStackableItem"/>
     <attributes>
-      <atk value="-1"/>
+      <ratk value="-1"/>
       <range value="8"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -30,7 +30,7 @@
     <description>You see a pile of vomit. Gross!</description>
     <implementation class-name="games.stendhal.server.entity.item.NoStatsStackableItem"/>
     <attributes>
-      <atk value="-1"/>
+      <ratk value="-1"/>
       <range value="5"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -52,7 +52,7 @@
     <description>You see a dart. You'll need to be close before you can use it as a missile. Stand square on, not diagonally, for the best results.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="2"/>
+      <ratk value="2"/>
       <range value="2"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -74,7 +74,7 @@
     <description>You see a power dart. You'll need to be close before you can use it as a missile. Stand square on, not diagonally, for the best results.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="4"/>
+      <ratk value="4"/>
       <range value="2"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -96,7 +96,7 @@
     <description>You see a shuriken. You'll need to be close before you can use it as a missile. Stand square on, not diagonally, for the best results.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="6"/>
+      <ratk value="6"/>
       <range value="3"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -118,7 +118,7 @@
     <description>You see a fire shuriken. Throwing this flaming missile unleashes fiendish power.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="12"/>
+      <ratk value="12"/>
       <range value="3"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>
@@ -141,7 +141,7 @@
     <description>You see a wooden spear. You can attack at a distance with this primitive weapon. Stand square on, not diagonally, for the best results.</description>
     <implementation class-name="games.stendhal.server.entity.item.StackableItem"/>
     <attributes>
-      <atk value="10"/>
+      <ratk value="10"/>
       <range value="4"/>
       <quantity value="1"/>
       <max_quantity value="2147483647"/>

--- a/data/conf/items/ranged.xml
+++ b/data/conf/items/ranged.xml
@@ -6,7 +6,7 @@
     <description>You see a wooden bow. With this in one hand, and wooden arrows in the other, you may be able to attack from a distance.</description>
     <implementation class-name="games.stendhal.server.entity.item.Item"/>
     <attributes>
-      <atk value="12"/>
+      <ratk value="12"/>
       <range value="3"/>
     </attributes>
     <weight value="1.0"/>
@@ -26,7 +26,7 @@
     <description>You see a longbow. Equipped with this, and a supply of arrows, you will have an effective ranged attack.</description>
     <implementation class-name="games.stendhal.server.entity.item.Item"/>
     <attributes>
-      <atk value="14"/>
+      <ratk value="14"/>
       <range value="4"/>
     </attributes>
     <weight value="1.0"/>
@@ -46,7 +46,7 @@
     <description>You see a composite bow. It's better strung than most bows, for excellent ranged attack.</description>
     <implementation class-name="games.stendhal.server.entity.item.Item"/>
     <attributes>
-      <atk value="15"/>
+      <ratk value="15"/>
       <range value="5"/>
     </attributes>
     <weight value="1.0"/>
@@ -66,7 +66,7 @@
  <description>You see a crossbow. The attack is high but it has a very short range, what do you prefer?</description>
     <implementation class-name="games.stendhal.server.entity.item.Item"/>
     <attributes>
-      <atk value="17"/>
+      <ratk value="17"/>
       <range value="3"/>
     </attributes>
     <weight value="3.0"/>
@@ -86,7 +86,7 @@
  <description>You see a hunter crossbow. You must decide if the high attack is worth the short range it has.</description>
     <implementation class-name="games.stendhal.server.entity.item.Item"/>
     <attributes>
-      <atk value="21"/>
+      <ratk value="21"/>
       <range value="4"/>
     </attributes>
     <weight value="3.0"/>
@@ -106,7 +106,7 @@
    <description>You see a light and strong mithril bow. Its impeccable workmanship affords incredible accuracy.</description>
     <implementation class-name="games.stendhal.server.entity.item.Item"/>
     <attributes>
-      <atk value="28"/>
+      <ratk value="28"/>
       <range value="4"/>
     </attributes>
     <weight value="3.0"/>

--- a/src/games/stendhal/client/entity/RPEntity.java
+++ b/src/games/stendhal/client/entity/RPEntity.java
@@ -33,7 +33,6 @@ import games.stendhal.common.ItemTools;
 import games.stendhal.common.NotificationType;
 import games.stendhal.common.constants.Nature;
 import games.stendhal.common.constants.SoundLayer;
-import games.stendhal.common.constants.Testing;
 import games.stendhal.common.grammar.Grammar;
 import marauroa.common.game.RPObject;
 import marauroa.common.game.RPObject.ID;
@@ -1333,14 +1332,11 @@ public abstract class RPEntity extends AudibleEntity {
 			def = changes.getInt("modified_def");
 		}
 
-		/* TODO: Remove condition when ranged stat testing is finished. */
-		if (Testing.COMBAT) {
-			if (changes.has("ratk")) {
-				ratk = changes.getInt("ratk");
-			}
-			if (changes.has("modified_ratk")) {
-				ratk = changes.getInt("modified_ratk");
-			}
+		if (changes.has("ratk")) {
+			ratk = changes.getInt("ratk");
+		}
+		if (changes.has("modified_ratk")) {
+			ratk = changes.getInt("modified_ratk");
 		}
 
 		if (changes.has("level")) {
@@ -1358,11 +1354,8 @@ public abstract class RPEntity extends AudibleEntity {
 			defXP = changes.getInt("def_xp");
 		}
 
-		/* TODO: Remove condition when ranged stat testing is finished. */
-		if (Testing.COMBAT) {
-			if (changes.has("ratk_xp")) {
-				ratkXP = changes.getInt("ratk_xp");
-			}
+		if (changes.has("ratk_xp")) {
+			ratkXP = changes.getInt("ratk_xp");
 		}
 
 		if (changes.has("atk_item")) {
@@ -1373,11 +1366,8 @@ public abstract class RPEntity extends AudibleEntity {
 			defItem = changes.getInt("def_item");
 		}
 
-		/* TODO: Remove condition when ranged stat testing is finished. */
-		if (Testing.COMBAT) {
-			if (changes.has("ratk_item")) {
-				ratkItem = changes.getInt("ratk_item");
-			}
+		if (changes.has("ratk_item")) {
+			ratkItem = changes.getInt("ratk_item");
 		}
 
 		if (changes.has("mana")) {

--- a/src/games/stendhal/client/gui/stats/StatsPanel.java
+++ b/src/games/stendhal/client/gui/stats/StatsPanel.java
@@ -21,7 +21,6 @@ import games.stendhal.client.gui.layout.SBoxLayout;
 import games.stendhal.client.gui.layout.SLayout;
 import games.stendhal.client.gui.styled.Style;
 import games.stendhal.client.gui.styled.StyleUtil;
-import games.stendhal.common.constants.Testing;
 
 /**
  * Display panel for status icons and player stats. The methods may be safely
@@ -64,13 +63,8 @@ class StatsPanel extends JPanel {
 		defLabel = new StatLabel();
 		add(defLabel, SLayout.EXPAND_X);
 
-		/* FIXME: ranged stat is disabled until fully implemented */
-		if (Testing.COMBAT) {
-			ratkLabel = new StatLabel();
-			add(ratkLabel, SLayout.EXPAND_X);
-		} else {
-			ratkLabel = null;
-		}
+		ratkLabel = new StatLabel();
+		add(ratkLabel, SLayout.EXPAND_X);
 
 		xpLabel = new StatLabel();
 		add(xpLabel, SLayout.EXPAND_X);

--- a/src/games/stendhal/client/gui/stats/StatsPanelController.java
+++ b/src/games/stendhal/client/gui/stats/StatsPanelController.java
@@ -24,7 +24,6 @@ import org.apache.log4j.Logger;
 import games.stendhal.client.entity.StatusID;
 import games.stendhal.common.Level;
 import games.stendhal.common.MathHelper;
-import games.stendhal.common.constants.Testing;
 import marauroa.common.game.RPObject;
 import marauroa.common.game.RPSlot;
 
@@ -120,12 +119,9 @@ public final class StatsPanelController {
 		addPropertyChangeListenerWithModifiedSupport(pcs, "def", listener);
 		pcs.addPropertyChangeListener("def_xp", listener);
 
-		/* TODO: Remove condition after ranged stat testing is finished. */
-		if (Testing.COMBAT) {
-			listener = new RATKChangeListener();
-			addPropertyChangeListenerWithModifiedSupport(pcs, "ratk", listener);
-			pcs.addPropertyChangeListener("ratk_xp", listener);
-		}
+		listener = new RATKChangeListener();
+		addPropertyChangeListenerWithModifiedSupport(pcs, "ratk", listener);
+		pcs.addPropertyChangeListener("ratk_xp", listener);
 
 		listener = new XPChangeListener();
 		pcs.addPropertyChangeListener("xp", listener);
@@ -139,11 +135,8 @@ public final class StatsPanelController {
 		listener = new ArmorChangeListener();
 		pcs.addPropertyChangeListener("def_item", listener);
 
-		/* FIXME: ranged stat is disabled by default until fully implemented */
-		if (Testing.COMBAT) {
-			listener = new RangedWeaponChangeListener();
-			pcs.addPropertyChangeListener("ratk_item", listener);
-		}
+		listener = new RangedWeaponChangeListener();
+		pcs.addPropertyChangeListener("ratk_item", listener);
 
 		listener = new MoneyChangeListener();
 		for (String slot : MONEY_SLOTS) {

--- a/src/games/stendhal/server/actions/admin/InspectAction.java
+++ b/src/games/stendhal/server/actions/admin/InspectAction.java
@@ -78,6 +78,8 @@ public class InspectAction extends AdministrationAction {
 			st.append("\nID: " + action.get("target") + " in " + inspected.getZone().getName() + " at (" + + inspected.getX() + ", " + + inspected.getY()+")");
 			st.append("\nATK:    " + inspected.getAtk() + "("
 					+ inspected.getAtkXP() + ")");
+			st.append("\nRATK:  " + inspected.getRatk() + "("
+					+ inspected.getRatkXP() + ")");
 			st.append("\nDEF:    " + inspected.getDef() + "("
 					+ inspected.getDefXP() + ")");
 			st.append("\nHP:     " + inspected.getHP() + " / "

--- a/src/games/stendhal/server/core/rp/StendhalRPAction.java
+++ b/src/games/stendhal/server/core/rp/StendhalRPAction.java
@@ -313,6 +313,9 @@ public class StendhalRPAction {
 		// Throw dices to determine if the attacker has missed the defender
 		final boolean beaten = player.canHit(defender);
 
+		// For checking if RATK XP should be incremented on successful hit
+		boolean addRatkXP = isRanged;
+
 		/* TODO: Remove if alternate attack training method implemented in
 		 *       game.
 		 *
@@ -326,6 +329,8 @@ public class StendhalRPAction {
 					&& player.getsFightXpFrom(defender)) {
 				if (isRanged) {
 					player.incRatkXP();
+					// don't allow player to receive double experience from successful hits
+					addRatkXP = false;
 				} else {
 					player.incAtkXP();
 				}
@@ -348,6 +353,11 @@ public class StendhalRPAction {
 
 			int damage = player.damageDone(defender, itemAtk, player.getDamageType());
 			if (damage > 0) {
+
+				if (addRatkXP && !(defender instanceof SpeakerNPC)) {
+					// Range attack XP is incremented for successful hits regardless of whether player has recently been hit
+					player.incRatkXP();
+				}
 
 				// limit damage to target HP
 				damage = Math.min(damage, defender.getHP());

--- a/src/games/stendhal/server/core/rp/StendhalRPAction.java
+++ b/src/games/stendhal/server/core/rp/StendhalRPAction.java
@@ -324,7 +324,11 @@ public class StendhalRPAction {
 			// disabled attack xp for attacking NPC's
 			if (!(defender instanceof SpeakerNPC)
 					&& player.getsFightXpFrom(defender)) {
-				player.incAtkXP();
+				if (isRanged) {
+					player.incRatkXP();
+				} else {
+					player.incAtkXP();
+				}
 			}
 		}
 
@@ -335,8 +339,14 @@ public class StendhalRPAction {
 			}
 
 			final List<Item> weapons = player.getWeapons();
+			final float itemAtk;
+			if (isRanged) {
+				itemAtk = player.getItemRatk();
+			} else {
+				itemAtk = player.getItemAtk();
+			}
 
-			int damage = player.damageDone(defender, player.getItemAtk(), player.getDamageType());
+			int damage = player.damageDone(defender, itemAtk, player.getDamageType());
 			if (damage > 0) {
 
 				// limit damage to target HP

--- a/src/games/stendhal/server/entity/RPEntity.java
+++ b/src/games/stendhal/server/entity/RPEntity.java
@@ -3128,10 +3128,13 @@ System.out.printf("  drop: %2d %2d\n", attackerRoll, defenderRoll);
 			&& (((getDamageType() == getRangedDamageType()) || squaredDistance(defender) > 0));
 
 		Nature nature;
+		final float itemAtk;
 		if (isRanged) {
 			nature = getRangedDamageType();
+			itemAtk = getItemRatk();
 		} else {
 			nature = getDamageType();
+			itemAtk = getItemAtk();
 		}
 
 		// Try to inflict a status effect
@@ -3149,7 +3152,7 @@ System.out.printf("  drop: %2d %2d\n", attackerRoll, defenderRoll);
 		if (this.canHit(defender)) {
 			defender.applyDefXP(this);
 
-			int damage = damageDone(defender, getItemAtk(), nature, isRanged, maxRange);
+			int damage = damageDone(defender, itemAtk, nature, isRanged, maxRange);
 
 			if (damage > 0) {
 

--- a/src/games/stendhal/server/entity/RPEntity.java
+++ b/src/games/stendhal/server/entity/RPEntity.java
@@ -2725,22 +2725,31 @@ System.out.printf("  drop: %2d %2d\n", attackerRoll, defenderRoll);
 			weapon += weaponItem.getAttack();
 		}
 
-		// range weapons
-		StackableItem ammunitionItem = null;
+		return weapon;
+	}
+
+	/**
+	 * Retrieves total range attack value of held weapon & ammunition.
+	 */
+	public float getItemRatk() {
+		float ratk = 0;
+		final List<Item> weapons = getWeapons();
+
 		if (weapons.size() > 0) {
-			if (weapons.get(0).isOfClass("ranged")) {
+			final Item held = getWeapons().get(0);
+			ratk += held.getRangedAttack();
+
+			StackableItem ammunitionItem = null;
+			if (held.isOfClass("ranged")) {
 				ammunitionItem = getAmmunition();
 
 				if (ammunitionItem != null) {
-					weapon += ammunitionItem.getAttack();
-				} else {
-					// If there is no ammunition...
-					weapon = 0;
+					ratk += ammunitionItem.getRangedAttack();
 				}
 			}
 		}
 
-		return weapon;
+		return ratk;
 	}
 
 	public float getItemDef() {
@@ -2829,6 +2838,7 @@ System.out.printf("  drop: %2d %2d\n", attackerRoll, defenderRoll);
 	 */
 	public void updateItemAtkDef() {
 		put("atk_item", ((int) getItemAtk()));
+		put("ratk_item", ((int) getItemRatk()));
 		put("def_item", ((int) getItemDef()));
 		notifyWorldAboutChanges();
 	}

--- a/src/games/stendhal/server/entity/RPEntity.java
+++ b/src/games/stendhal/server/entity/RPEntity.java
@@ -488,12 +488,9 @@ public abstract class RPEntity extends GuidedEntity {
 			setDefXpInternal(def_xp, false);
 		}
 
-		/* TODO: Remove condition after ranged stat testing is finished. */
-		if (Testing.COMBAT) {
-			if (has("ratk_xp")) {
-				ratk_xp = getInt("ratk_xp");
-				setRatkXPInternal(ratk_xp, false);
-			}
+		if (has("ratk_xp")) {
+			ratk_xp = getInt("ratk_xp");
+			setRatkXPInternal(ratk_xp, false);
 		}
 
 		if (has("base_hp")) {
@@ -589,10 +586,7 @@ public abstract class RPEntity extends GuidedEntity {
 		 * XXX: atkStrength never used outside of debugger.
 		 */
 		final int atkStrength, sourceAtk;
-		/* TODO: Remove COMBAT condition when ranged attack testing is
-		 *       finished.
-		 */
-		if (isRanged && Testing.COMBAT) {
+		if (isRanged) {
 			atkStrength = this.getRatk();
 			sourceAtk = this.getCappedRatk();
 		} else {
@@ -3007,10 +3001,7 @@ System.out.printf("  drop: %2d %2d\n", attackerRoll, defenderRoll);
 		}
 
 		final int attackerATK;
-		/* TODO: Remove Testing.COMBAT condition check when ranged stat
-		 * testing is finished.
-		 */
-		if (usesRanged && Testing.COMBAT) {
+		if (usesRanged) {
 			attackerATK = this.getCappedRatk(); // player is using ranged weapon
 		} else {
 			attackerATK = this.getCappedAtk(); // player is using hand-to-hand

--- a/src/games/stendhal/server/entity/RPEntityRPClass.java
+++ b/src/games/stendhal/server/entity/RPEntityRPClass.java
@@ -14,7 +14,6 @@ package games.stendhal.server.entity;
 
 import static games.stendhal.common.constants.Common.PATHSET;
 
-import games.stendhal.common.constants.Testing;
 import marauroa.common.game.Definition;
 import marauroa.common.game.Definition.Type;
 import marauroa.common.game.RPClass;
@@ -51,18 +50,13 @@ public class RPEntityRPClass {
         entity.addAttribute("def_xp", Type.INT, Definition.PRIVATE);
         entity.addAttribute("def_item", Type.INT,
                 (byte) (Definition.PRIVATE | Definition.VOLATILE));
-        /* TODO: Remove condition when ranged stat testing is finished. */
-        if (Testing.COMBAT) {
-        	// FIXME: remove VOLATILE when ranged stat is ready
-//        	entity.addAttribute("ratk", Type.SHORT, Definition.PRIVATE);
-//        	entity.addAttribute("ratk_xp", Type.INT, Definition.PRIVATE);
-	        entity.addAttribute("ratk", Type.SHORT,
-	        		(byte) (Definition.PRIVATE | Definition.VOLATILE));
-	        entity.addAttribute("ratk_xp", Type.INT,
-	        		(byte) (Definition.PRIVATE | Definition.VOLATILE));
-	        entity.addAttribute("ratk_item", Type.INT,
-	                (byte) (Definition.PRIVATE | Definition.VOLATILE));
-        }
+    	// FIXME: remove VOLATILE when ranged stat is ready
+        entity.addAttribute("ratk", Type.SHORT,
+        		(byte) (Definition.PRIVATE | Definition.VOLATILE));
+        entity.addAttribute("ratk_xp", Type.INT,
+        		(byte) (Definition.PRIVATE | Definition.VOLATILE));
+        entity.addAttribute("ratk_item", Type.INT,
+                (byte) (Definition.PRIVATE | Definition.VOLATILE));
 
         entity.addAttribute("risk", Type.BYTE, Definition.VOLATILE); // obsolete, do not use
         entity.addAttribute("damage", Type.INT, Definition.VOLATILE); // obsolete, do not use

--- a/src/games/stendhal/server/entity/RPEntityRPClass.java
+++ b/src/games/stendhal/server/entity/RPEntityRPClass.java
@@ -50,11 +50,8 @@ public class RPEntityRPClass {
         entity.addAttribute("def_xp", Type.INT, Definition.PRIVATE);
         entity.addAttribute("def_item", Type.INT,
                 (byte) (Definition.PRIVATE | Definition.VOLATILE));
-    	// FIXME: remove VOLATILE when ranged stat is ready
-        entity.addAttribute("ratk", Type.SHORT,
-        		(byte) (Definition.PRIVATE | Definition.VOLATILE));
-        entity.addAttribute("ratk_xp", Type.INT,
-        		(byte) (Definition.PRIVATE | Definition.VOLATILE));
+        entity.addAttribute("ratk", Type.SHORT, Definition.PRIVATE);
+        entity.addAttribute("ratk_xp", Type.INT, Definition.PRIVATE);
         entity.addAttribute("ratk_item", Type.INT,
                 (byte) (Definition.PRIVATE | Definition.VOLATILE));
 

--- a/src/games/stendhal/server/entity/player/Player.java
+++ b/src/games/stendhal/server/entity/player/Player.java
@@ -42,7 +42,6 @@ import games.stendhal.common.TradeState;
 import games.stendhal.common.Version;
 import games.stendhal.common.constants.Nature;
 import games.stendhal.common.constants.SoundLayer;
-import games.stendhal.common.constants.Testing;
 import games.stendhal.common.grammar.Grammar;
 import games.stendhal.common.parser.WordList;
 import games.stendhal.server.core.engine.GameEvent;
@@ -183,11 +182,8 @@ public class Player extends RPEntity implements UseListener {
 		player.put("atk_xp", 0);
 		player.put("def", 10);
 		player.put("def_xp", 0);
-		/* TODO: Remove condition after ranged stat testing is finished. */
-		if (Testing.COMBAT) {
-			player.put("ratk", 10);
-			player.put("ratk_xp", 0);
-		}
+		player.put("ratk", 10);
+		player.put("ratk_xp", 0);
 		player.put("level", 0);
 		player.setXP(0);
 
@@ -279,34 +275,34 @@ public class Player extends RPEntity implements UseListener {
 
 		unlockedPortals = new LinkedList<Integer>();
 
-		/* TODO: Remove condition when ranged stat testing is finished. */
-		if (Testing.COMBAT) {
+		/*
+		 * TODO: Remove if VOLATILE definition is removed from "ratk" and
+		 * "ratk_xp" attributes.
+		 */
+		if (!this.has("ratk_xp")) {
 			/*
-			 * TODO: Remove if VOLATILE definition is removed from "ratk" and
-			 * "ratk_xp" attributes.
+			 * If an existing character does not have ranged stat set it at
+			 * same level and experience as new character.
 			 */
-			if (!this.has("ratk_xp")) {
-				/*
-				 * If an existing character does not have ranged stat set it at
-				 * same level and experience as new character.
-				 */
-				this.put("ratk", 10);
-				this.put("ratk_xp", 0);
+			this.put("ratk", 10);
+			this.put("ratk_xp", 0);
 
+			/*
+			 * if player's current level is 20 or higher give a buffer based
+			 * on about 25% of current atk experience.
+			 */
+			/*
+			if (this.getLevel() > 19) {
 				/*
-				 * if player's current level is 20 or higher give a buffer based
-				 * on about 25% of current atk experience.
+				 * Using setRatkXPinternal() instead of setRatkXP() here to
+				 * avoid multiple calls to updateModifiedAttributes().
 				 */
-				if (this.getLevel() > 19) {
-					/*
-					 * Using setRatkXPinternal() instead of setRatkXP() here to
-					 * avoid multiple calls to updateModifiedAttributes().
-					 */
-					// FIXME: Is this formula accurate?
-					this.setRatkXPInternal((int) (this.getAtkXP() * 0.0026),
-							false);
-				}
+				/*
+				// FIXME: Is this formula accurate?
+				this.setRatkXPInternal((int) (this.getAtkXP() * 0.0026),
+						false);
 			}
+			*/
 		}
 
 		updateModifiedAttributes();

--- a/src/games/stendhal/server/entity/player/Player.java
+++ b/src/games/stendhal/server/entity/player/Player.java
@@ -274,37 +274,6 @@ public class Player extends RPEntity implements UseListener {
 		}
 
 		unlockedPortals = new LinkedList<Integer>();
-
-		/*
-		 * TODO: Remove if VOLATILE definition is removed from "ratk" and
-		 * "ratk_xp" attributes.
-		 */
-		if (!this.has("ratk_xp")) {
-			/*
-			 * If an existing character does not have ranged stat set it at
-			 * same level and experience as new character.
-			 */
-			this.put("ratk", 10);
-			this.put("ratk_xp", 0);
-
-			/*
-			 * if player's current level is 20 or higher give a buffer based
-			 * on about 25% of current atk experience.
-			 */
-			/*
-			if (this.getLevel() > 19) {
-				/*
-				 * Using setRatkXPinternal() instead of setRatkXP() here to
-				 * avoid multiple calls to updateModifiedAttributes().
-				 */
-				/*
-				// FIXME: Is this formula accurate?
-				this.setRatkXPInternal((int) (this.getAtkXP() * 0.0026),
-						false);
-			}
-			*/
-		}
-
 		updateModifiedAttributes();
 	}
 

--- a/src/games/stendhal/server/entity/player/UpdateConverter.java
+++ b/src/games/stendhal/server/entity/player/UpdateConverter.java
@@ -21,7 +21,6 @@ import org.apache.log4j.Logger;
 
 import games.stendhal.common.ItemTools;
 import games.stendhal.common.KeyedSlotUtil;
-import games.stendhal.common.constants.Testing;
 import games.stendhal.server.core.engine.SingletonRepository;
 import games.stendhal.server.core.rule.EntityManager;
 import games.stendhal.server.entity.Outfit;
@@ -231,10 +230,6 @@ public abstract class UpdateConverter {
     	if (!object.has("atk_xp")) {
     		object.put("atk_xp", "0");
     		object.put("def_xp", "0");
-    		/* TODO: Remove condition after ranged stat testing is finished. */
-    		if (Testing.COMBAT) {
-    			object.put("ratk_xp", "0");
-    		}
     	}
 
     	if (object.has("devel")) {
@@ -246,11 +241,12 @@ public abstract class UpdateConverter {
     		object.put("release", "0.00");
     		object.put("atk", "10");
     		object.put("def", "10");
-    		/* TODO: Remove condition after ranged stat testing is finished. */
-    		if (Testing.COMBAT) {
-    			object.put("ratk", "10");
-    		}
     	}
+
+    	// Port to <next version>
+		if (!object.has("ratk_xp")) {
+			object.put("ratk_xp", "10");
+		}
 
     	if (!object.has("age")) {
     		object.put("age", "0");

--- a/src/games/stendhal/server/entity/player/UpdateConverter.java
+++ b/src/games/stendhal/server/entity/player/UpdateConverter.java
@@ -243,7 +243,6 @@ public abstract class UpdateConverter {
     		object.put("def", "10");
     	}
 
-    	// Port to <next version>
 		if (!object.has("ratk_xp")) {
 			object.put("ratk_xp", "0");
 		}

--- a/src/games/stendhal/server/entity/player/UpdateConverter.java
+++ b/src/games/stendhal/server/entity/player/UpdateConverter.java
@@ -245,7 +245,7 @@ public abstract class UpdateConverter {
 
     	// Port to <next version>
 		if (!object.has("ratk_xp")) {
-			object.put("ratk_xp", "10");
+			object.put("ratk_xp", "0");
 		}
 
     	if (!object.has("age")) {


### PR DESCRIPTION
Creates the ***RATK*** stat used exclusively for attacking with ranged weapons.
- Attack success & power calculated from ***RATK*** instead of ***ATK***.
- Range attack XP is on successful hits regardless of whether the player has been hit recently.
  - If player has been hit recently, misses still increment ***RATK XP***.