### PR TITLE
Fixed NPE in test by adding test zone to world.

### DIFF
--- a/tests/games/stendhal/server/maps/nalwor/forest/ArcheryRangeTest.java
+++ b/tests/games/stendhal/server/maps/nalwor/forest/ArcheryRangeTest.java
@@ -28,12 +28,14 @@ import org.junit.Test;
 
 import games.stendhal.common.MathHelper;
 import games.stendhal.server.core.engine.SingletonRepository;
+import games.stendhal.server.core.engine.StendhalRPWorld;
 import games.stendhal.server.core.engine.StendhalRPZone;
 import games.stendhal.server.entity.mapstuff.sign.ShopSign;
 import games.stendhal.server.entity.npc.ConversationStates;
 import games.stendhal.server.entity.npc.SpeakerNPC;
 import games.stendhal.server.entity.npc.fsm.Engine;
 import games.stendhal.server.entity.player.Player;
+import games.stendhal.server.maps.MockStendlRPWorld;
 import games.stendhal.server.maps.quests.AbstractQuest;
 import utilities.QuestHelper;
 import utilities.ZoneAndPlayerTestImpl;
@@ -66,13 +68,10 @@ public class ArcheryRangeTest extends ZoneAndPlayerTestImpl {
 	@Override
 	public void setUp() throws Exception {
 		// FIXME: misspelled "MockStendlRPWorld"?
-		//final StendhalRPWorld world = MockStendlRPWorld.get();
-		//final StendhalRPWorld world = StendhalRPWorld.get();
-
-		//assertTrue(world.)
+		final StendhalRPWorld world = MockStendlRPWorld.get();
 
 		final StendhalRPZone zone = new StendhalRPZone("test_zone");
-		//final StendhalRPZone zone = world.getZone("0_nalwor_forest_n");
+		world.addRPZone(zone);
 		final ArcheryRange range = new ArcheryRange();
 		range.configureZone(zone, null);
 
@@ -208,10 +207,6 @@ public class ArcheryRangeTest extends ZoneAndPlayerTestImpl {
 		en.step(player, "hi");
 
 		// player is new to archery range
-		/* FIXME: NullPointerException because NPC checks for player count in
-		 *        archery training area. But zone where archery range is does
-		 *        not actually exist.
-		 */
 		en.step(player, "train");
 		assertEquals("Hmmm, I haven't seen you around here before."
 				+ " But you have the proper credentials. Do you want me to"


### PR DESCRIPTION
Fixing failing test:

    games.stendhal.server.maps.nalwor.forest.ArcheryRangeTest.testTrainingWithID

### Stacktrace

    java.lang.NullPointerException
    	at games.stendhal.server.util.Area.getPlayers(Area.java:117)
    	at games.stendhal.server.entity.npc.condition.AreaIsFullCondition.fire(AreaIsFullCondition.java:41)
    	at games.stendhal.server.entity.npc.condition.AndCondition.fire(AndCondition.java:47)
    	at games.stendhal.server.entity.npc.fsm.Transition.isConditionFulfilled(Transition.java:386)
    	at games.stendhal.server.entity.npc.fsm.Engine.matchTransition(Engine.java:524)
    	at games.stendhal.server.entity.npc.fsm.Engine.step(Engine.java:439)
    	at games.stendhal.server.entity.npc.fsm.Engine.step(Engine.java:421)
    	at games.stendhal.server.maps.nalwor.forest.ArcheryRangeTest.testTrainingWithID(ArcheryRangeTest.java:215)
