### PR TITLE
fix TanneryNPCTest

### DIFF
--- a/tests/games/stendhal/server/maps/deniran/cityinterior/tannery/TannerNPCTest.java
+++ b/tests/games/stendhal/server/maps/deniran/cityinterior/tannery/TannerNPCTest.java
@@ -305,9 +305,12 @@ public class TannerNPCTest extends ZonePlayerAndNPCTestImpl {
 		assertEquals(ConversationStates.QUESTION_1, en.getCurrentState());
 		en.step(player, "yes");
 		assertEquals(ConversationStates.IDLE, en.getCurrentState());
-		assertEquals(
-				"Okay, I will begin making your money pouch. Please come back in 24 hours.",
-				getReply(tanner));
+
+		String readyReply = getReply(tanner);
+		assertTrue(
+				readyReply.equals("Okay, I will begin making your money pouch. Please come back in 24 hours.") ||
+				readyReply.equals("Okay, I will begin making your money pouch. Please come back in 1 day."));
+		
 		assertFalse(player.getQuest(QUEST_SLOT).equals("start"));
 		assertFalse(player.isEquipped("pouch"));
 		assertFalse(player.isEquipped("money"));


### PR DESCRIPTION
Test for TanneryNPC now accepts two slightly different expressions for the quest delay (24h and 1d). Tanner's answer can differ according to execution speed