### PR TITLE
Fix habanero peppers

### DIFF
--- a/src/games/stendhal/common/parser/words.txt
+++ b/src/games/stendhal/common/parser/words.txt
@@ -688,6 +688,7 @@ path	OBJ	paths
 payment	OBJ	payments
 pear	OBJ-FOO
 pearl	OBJ	pearls
+pepper	OBJ-FOO peppers
 perch	OBJ-FOO-ANI	perches
 pestle	OBJ	pestles
 pet	OBJ-ANI	pets

--- a/src/games/stendhal/server/core/rp/DaylightPhase.java
+++ b/src/games/stendhal/server/core/rp/DaylightPhase.java
@@ -33,7 +33,7 @@ public enum DaylightPhase {
 	DAY ("day"),
 
 	/** the sun is setting */
-	SUNSET (0xc0a080, "unset"),
+	SUNSET (0xc0a080, "sunset"),
 
 	/** early night */
 	DUSK (0x774590, "night");


### PR DESCRIPTION
Two minor corrections: 
"habanero peppers" were not understood in the plural form (when buying) 
Sue stating a "nice unset" at dusk was short of an "s"