### PR TITLE
correction in Javadoc for 'Herbs for Carmen'-Quest

### DIFF
--- a/src/games/stendhal/server/maps/quests/HerbsForCarmen.java
+++ b/src/games/stendhal/server/maps/quests/HerbsForCarmen.java
@@ -61,8 +61,8 @@ import games.stendhal.server.util.ItemCollection;
  * REWARD:
  * <ul>
  * <li>50 XP</li>
- * <li>2 antidote</li>
- * <li>Karma: 10</li>
+ * <li>5 minor potions</li>
+ * <li>Karma: 5</li>
  * </ul>
  *
  * REPETITIONS:


### PR DESCRIPTION
Reward in javadoc in "Herbs for Carmen" was not consistent with source. Also fixed page in Wiki.