### PR TITLE
Fix Jessica facing away

### DIFF
--- a/src/games/stendhal/server/maps/athor/holiday_area/FerryConveyerNPC.java
+++ b/src/games/stendhal/server/maps/athor/holiday_area/FerryConveyerNPC.java
@@ -19,6 +19,7 @@ import games.stendhal.common.parser.Sentence;
 import games.stendhal.server.core.config.ZoneConfigurator;
 import games.stendhal.server.core.engine.SingletonRepository;
 import games.stendhal.server.core.engine.StendhalRPZone;
+import games.stendhal.server.entity.RPEntity;
 import games.stendhal.server.entity.npc.ChatAction;
 import games.stendhal.server.entity.npc.ConversationPhrases;
 import games.stendhal.server.entity.npc.ConversationStates;
@@ -116,6 +117,11 @@ public class FerryConveyerNPC implements ZoneConfigurator  {
 						ConversationStates.ATTENDING,
 						"You don't know what you're missing, landlubber!", null);
 
+			}
+
+			@Override
+			protected void onGoodbye(final RPEntity player) {
+				setDirection(Direction.LEFT);
 			}};
 
 			new AthorFerry.FerryListener() {


### PR DESCRIPTION
Set direction to left for NPC Jessica after conversation is over, to avoid her facing away after sending player to ferry.

Resolves: #382