### PR TITLE
Reworking Combat

### DIFF
--- a/src/games/stendhal/server/entity/RPEntity.java
+++ b/src/games/stendhal/server/entity/RPEntity.java
@@ -3068,7 +3068,7 @@ System.out.printf("  drop: %2d %2d\n", attackerRoll, defenderRoll);
 		return risk > 0;
 	}
 
-	int calculateRiskForCanHit(final int roll, final int defenderDEF,
+	protected int calculateRiskForCanHit(final int roll, final int defenderDEF,
 			final int attackerATK) {
 		return 20 * attackerATK - roll * defenderDEF;
 	}

--- a/src/games/stendhal/server/entity/RPEntity.java
+++ b/src/games/stendhal/server/entity/RPEntity.java
@@ -553,7 +553,7 @@ public abstract class RPEntity extends CombatEntity {
 	 * @return The number of hitpoints that the target should lose. 0 if the
 	 *         attack was completely blocked by the defender.
 	 */
-	int damageDone(RPEntity defender, double attackingWeaponsValue, Nature damageType,
+	private int damageDone(RPEntity defender, double attackingWeaponsValue, Nature damageType,
 			boolean isRanged, int maxRange) {
 		// Don't start from 0 to mitigate weird behaviour at very low levels
 		final int effectiveAttackerLevel = getLevel() + 5;

--- a/src/games/stendhal/server/entity/RPEntity.java
+++ b/src/games/stendhal/server/entity/RPEntity.java
@@ -538,7 +538,7 @@ public abstract class RPEntity extends CombatEntity {
 	 * @return The number of hitpoints that the target should lose. 0 if the
 	 *         attack was completely blocked by the defender.
 	 */
-	private int damageDone(RPEntity defender, double attackingWeaponsValue, Nature damageType,
+	protected int damageDone(RPEntity defender, double attackingWeaponsValue, Nature damageType,
 			boolean isRanged, int maxRange) {
 		// Don't start from 0 to mitigate weird behaviour at very low levels
 		final int effectiveAttackerLevel = getLevel() + 5;

--- a/src/games/stendhal/server/entity/player/Player.java
+++ b/src/games/stendhal/server/entity/player/Player.java
@@ -2049,7 +2049,7 @@ public class Player extends DressedEntity implements UseListener {
 
 	@Override
 	protected void applyDefXP(final RPEntity entity) {
-		if (getsFightXpFrom(entity)) {
+		if (getsDefXpFrom(entity)) {
 			incDefXP();
 		}
 	}

--- a/src/games/stendhal/server/entity/player/Player.java
+++ b/src/games/stendhal/server/entity/player/Player.java
@@ -2921,13 +2921,20 @@ public class Player extends DressedEntity implements UseListener {
 	/**
 	 * This hack doubles the chance that a player can hit an enemy
 	 * to make the game feel more fair. However, in order to avoid
-	 * drastic changes to the game's balance, we will need to
-	 * reduce the amount of damage done by players.
+	 * drastic changes to the game's balance, we need to reduce
+	 * the amount of damage done by players. See:
+	 *     Player.damageDone.
 	 */
 	@Override
 	protected int calculateRiskForCanHit(final int roll, final int defenderDEF,
 			final int attackerATK) {
 		// use 40 as multiple for players instead of 20
 		return 40 * attackerATK - roll * defenderDEF;
+	}
+
+	@Override
+	public int damageDone(final RPEntity defender, double attackingWeaponsValue, Nature damageType) {
+		// compensate for player doubled chance of hit
+		return (int) Math.ceil(super.damageDone(defender, attackingWeaponsValue, damageType) / 2.0);
 	}
 }

--- a/src/games/stendhal/server/entity/player/Player.java
+++ b/src/games/stendhal/server/entity/player/Player.java
@@ -2928,12 +2928,20 @@ public class Player extends DressedEntity implements UseListener {
 	@Override
 	protected int calculateRiskForCanHit(final int roll, final int defenderDEF,
 			final int attackerATK) {
+		if (!games.stendhal.common.constants.Testing.TESTSERVER) {
+			return super.calculateRiskForCanHit(roll, defenderDEF, attackerATK);
+		}
+
 		// use 40 as multiple for players instead of 20
 		return 40 * attackerATK - roll * defenderDEF;
 	}
 
 	@Override
 	public int damageDone(final RPEntity defender, double attackingWeaponsValue, Nature damageType) {
+		if (!games.stendhal.common.constants.Testing.TESTSERVER) {
+			return super.damageDone(defender, attackingWeaponsValue, damageType);
+		}
+
 		// compensate for player doubled chance of hit
 		return (int) Math.ceil(super.damageDone(defender, attackingWeaponsValue, damageType) / 2.0);
 	}

--- a/src/games/stendhal/server/entity/player/Player.java
+++ b/src/games/stendhal/server/entity/player/Player.java
@@ -2917,4 +2917,17 @@ public class Player extends DressedEntity implements UseListener {
 		String[] values = value.split(" ");
 		return Integer.parseInt(values[0]) * Integer.parseInt(values[1]);
 	}
+
+	/**
+	 * This hack doubles the chance that a player can hit an enemy
+	 * to make the game feel more fair. However, in order to avoid
+	 * drastic changes to the game's balance, we will need to
+	 * reduce the amount of damage done by players.
+	 */
+	@Override
+	protected int calculateRiskForCanHit(final int roll, final int defenderDEF,
+			final int attackerATK) {
+		// use 40 as multiple for players instead of 20
+		return 40 * attackerATK - roll * defenderDEF;
+	}
 }

--- a/tests/games/stendhal/server/entity/RPEntityTest.java
+++ b/tests/games/stendhal/server/entity/RPEntityTest.java
@@ -353,7 +353,7 @@ public class RPEntityTest {
 			}
 
 			@Override
-			public int damageDone(final RPEntity defender, double attackingWeaponsValue,
+			protected int damageDone(final RPEntity defender, double attackingWeaponsValue,
 					Nature damageType, boolean ranged, int maxRange) {
 				return 30;
 			}


### PR DESCRIPTION
Changes designed to increase player satisfaction with the combat system.

One of the most frustrating things about fighting is the disparity in hit chance between players & creatures. This attempts to give more of a fair feel to combat by increasing player hit chance.

It also suggests a method of rewarding ATK XP for all players involved in team killing.

Changes:
- player hit chance doubled
  - damage inflicted by player halved to compensate (has not been tested in PvP)
- ATK XP rewarded for successful or blocked hits regardless of having recently taken damage
- missed hits never reward ATK XP

Reference issues:
- https://github.com/arianne/stendhal/issues/408