### PR TITLE
UI rendering method names moved out of enum

### DIFF
--- a/src/games/stendhal/client/UiRenderingMethod.java
+++ b/src/games/stendhal/client/UiRenderingMethod.java
@@ -29,36 +29,28 @@ import java.util.List;
  */
 public enum UiRenderingMethod {
 
-	DEFAULT("", "Default (system)"),
+	DEFAULT(""),
 
-	DIRECT_DRAW("", "Default (DirectDraw)"),
+	DIRECT_DRAW("directdraw"),
 
-	DIRECT_DRAW_SCALE("ddraw_scale", "DirectDraw HW scaling"),
+	DDRAW_HWSCALE("hw_scale"),
 
-	SOFTWARE("software", "Software rendering"),
+	SOFTWARE("software"),
 
-	WINDOWS_API("software", "Windows API"),
+	OPEN_GL("opengl"),
 
-	OPEN_GL("opengl", "Open GL"),
+	XRENDER("xrender"),
 
-	XRENDER("xrender", "XRender"),
-
-	METAL("metal", "Metal Framework");
+	METAL("metal");
 
 	private final String propertyValue;
-	private final String displayName;
 
-	private UiRenderingMethod(String propertyValue, String displayName) {
+	private UiRenderingMethod(String propertyValue) {
 		this.propertyValue = propertyValue;
-		this.displayName = displayName;
 	}
 
 	public String getPropertyValue() {
 		return propertyValue;
-	}
-
-	public String getDisplayName() {
-		return displayName;
 	}
 
 	public static UiRenderingMethod fromPropertyValue(String propertyValue) {
@@ -76,9 +68,10 @@ public enum UiRenderingMethod {
 
 		final String platformOs = System.getProperty("os.name").toLowerCase();
 		if (platformOs.startsWith("windows")) {
+			methods.add(DEFAULT);
 			methods.add(DIRECT_DRAW);
-			methods.add(DIRECT_DRAW_SCALE);
-			methods.add(WINDOWS_API);
+			methods.add(DDRAW_HWSCALE);
+			methods.add(SOFTWARE);
 			methods.add(OPEN_GL);
 		} else if (platformOs.startsWith("mac os")) {
 			methods.add(DEFAULT);

--- a/src/games/stendhal/client/gui/settings/VisualSettings.java
+++ b/src/games/stendhal/client/gui/settings/VisualSettings.java
@@ -451,12 +451,12 @@ class VisualSettings {
 	 * @return component
 	 */
 	private JComponent createRenderingSelector() {
-		final JComboBox<UiRenderingMethod> selector = new JComboBox<>();
+		final JComboBox<RenderingMethod> selector = new JComboBox<>();
 		selector.setRenderer(new DefaultListCellRenderer() {
 			@Override
 			public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
 					boolean cellHasFocus) {
-				return super.getListCellRendererComponent(list, ((UiRenderingMethod) value).getDisplayName(), index,
+				return super.getListCellRendererComponent(list, ((RenderingMethod) value).name, index,
 						isSelected, cellHasFocus);
 			}
 		});
@@ -466,17 +466,53 @@ class VisualSettings {
 
 		// Fill with available methods
 		for (UiRenderingMethod method : UiRenderingMethod.getAvailableMethods()) {
-			selector.addItem(method);
+			RenderingMethod item = new RenderingMethod();
+			item.method = method;
+			switch (method) {
+			case DEFAULT: {
+				item.name = "Default (system)";
+				break;
+			}
+			case SOFTWARE: {
+				if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+					item.name = "Windows API/GDI Software Rendering";
+				} else {
+					item.name = "Software Rendering";
+				}
+				break;
+			}
+			case DIRECT_DRAW: {
+				item.name = "DirectDraw Only";
+				break;
+			}
+			case DDRAW_HWSCALE: {
+				item.name = "Direct3D HW Scaling";
+				break;
+			}
+			case OPEN_GL: {
+				item.name = "Open GL";
+				break;
+			}
+			case XRENDER: {
+				item.name = "XRender";
+				break;
+			}
+			case METAL: {
+				item.name = "Metal Framework";
+				break;
+			}
+			}
+			selector.addItem(item);
 			if (method.getPropertyValue().equals(currentMethod))
-				selector.setSelectedItem(method);
+				selector.setSelectedItem(item);
 		}
 
 		selector.addActionListener(new ActionListener() {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				UiRenderingMethod selected = (UiRenderingMethod) selector.getSelectedItem();
-				wm.setProperty(SettingsProperties.UI_RENDERING, selected.getPropertyValue());
+				RenderingMethod selected = (RenderingMethod) selector.getSelectedItem();
+				wm.setProperty(SettingsProperties.UI_RENDERING, selected.method.getPropertyValue());
 				ClientSingletonRepository.getUserInterface()
 						.addEventLine(new EventLine("",
 								"The new rendering will be used the next time you start the game client.",
@@ -663,5 +699,10 @@ class VisualSettings {
 			}
 			return comp;
 		}
+	}
+
+	private static class RenderingMethod {
+		UiRenderingMethod method;
+		String name;
 	}
 }

--- a/src/games/stendhal/client/stendhal.java
+++ b/src/games/stendhal/client/stendhal.java
@@ -279,9 +279,15 @@ public final class stendhal {
 					System.setProperty("sun.java2d.noddraw", "true");
 					break;
 				}
-				case DIRECT_DRAW_SCALE: {
+				case DIRECT_DRAW: {
+					System.setProperty("sun.java2d.d3d", "false");
+					break;
+				}
+				case DDRAW_HWSCALE: {
+					System.setProperty("sun.java2d.d3d", "true");
+					System.setProperty("sun.java2d.ddforcevram", "true");
 					System.setProperty("sun.java2d.translaccel", "true");
-					System.setProperty("ddscale", "true");
+					System.setProperty("sun.java2d.ddscale", "true");
 					break;
 				}
 				case OPEN_GL: {


### PR DESCRIPTION
Cleanup of UI rendering switching - names for options moved outside of enum (for example to allow translation to different languages in the future)

Added DirectDraw only mode - tested in Windows 11 to have different GPU load during rendering