### PR TITLE
Save typedoc & showdown Node modules as dev depends to prevent re-downloading

### DIFF
--- a/buildtools/ant_modules/dist.xml
+++ b/buildtools/ant_modules/dist.xml
@@ -662,23 +662,6 @@
 
 	<!-- START: web client -->
 
-	<target name="js-prepare-contribs">
-		<!-- convert contributors markdown to HTML -->
-		<exec executable="npm${executable.suffix}" failonerror="true">
-			<arg value="install"/>
-			<arg value="showdown"/>
-			<arg value="--no-save"/>
-		</exec>
-		<exec executable="npx${executable.suffix}" failonerror="true">
-			<arg value="showdown"/>
-			<arg value="makehtml"/>
-			<arg value="--input"/>
-			<arg value="doc/contributors.md"/>
-			<arg value="--output"/>
-			<arg value="${srcjs}/contributors.html"/>
-		</exec>
-	</target>
-
 	<target name="js-prepare-marauroa">
 		<mkdir dir="build/js"/>
 		<unzip dest="build" src="libs/marauroa.jar">
@@ -703,13 +686,25 @@
 	</target>
 
 
-	<extension-point name="js-prepare" depends="js-prepare-contribs,js-prepare-marauroa,js-prepare-build,js-prepare-node"/>
+	<extension-point name="js-prepare" depends="js-prepare-marauroa,js-prepare-build,js-prepare-node,js-prepare-contribs"/>
 
 
 	<target name="js-prepare-node">
 		<exec executable="npm${executable.suffix}" failonerror="true">
 			<arg value="install"/>
 			<arg value="--no-save"/>
+		</exec>
+	</target>
+
+
+	<target name="js-prepare-contribs" depends="js-prepare-node">
+		<exec executable="npx${executable.suffix}" failonerror="true">
+			<arg value="showdown"/>
+			<arg value="makehtml"/>
+			<arg value="--input"/>
+			<arg value="doc/contributors.md"/>
+			<arg value="--output"/>
+			<arg value="${srcjs}/contributors.html"/>
 		</exec>
 	</target>
 

--- a/buildtools/ant_modules/docs.xml
+++ b/buildtools/ant_modules/docs.xml
@@ -87,12 +87,7 @@
 	</target>
 
 
-	<target name="tsdocs" depends="clean_tsdocs">
-		<exec executable="npm${executable.suffix}" failonerror="true">
-			<arg value="install"/>
-			<arg value="typedoc"/>
-			<arg value="--no-save"/>
-		</exec>
+	<target name="tsdocs" depends="clean_tsdocs,js-prepare-node">
 		<exec executable="npx${executable.suffix}" dir="${srcjs}/stendhal" failonerror="true">
 			<arg value="typedoc"/>
 			<arg value="--entryPointStrategy"/>

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   "private": true,
   "dependencies": {
     "typescript": "^5.2.0"
+  },
+  "devDependencies": {
+    "showdown": "^2.1.0",
+    "typedoc": "^0.25.12"
   }
 }


### PR DESCRIPTION
Adds typedoc & showdown Node modules as dev dependencies to prevent `ant js-prepare-node` from deleting them & therefore requiring re-download when executing `ant tsdocs` & `ant js-prepare-contribs`.

I looked for a way to prevent Node from deleting the modules without adding them as dev dependencies but haven't found any.