### PR TITLE
Age Achievements

### DIFF
--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -10,6 +10,7 @@ Changelog
   - Cutting Teeth: Accumulate 24 hours of play time
   - Adolescent: Accumulate a week of play time
   - Acclimating: Accumulate a month of play time
+  - Sturdy Foundation: Accumulate 6 months of play time
 
 *web client*
 - fixed text extending past edge of notification bubbles

--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -8,6 +8,7 @@ Changelog
 - renamed chef Patrick to Preston
 - new achievements:
   - Cutting Teeth: Accumulate 24 hours of play time
+  - Adolescent: Accumulate a week of play time
 
 *web client*
 - fixed text extending past edge of notification bubbles

--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -9,6 +9,7 @@ Changelog
 - new achievements:
   - Cutting Teeth: Accumulate 24 hours of play time
   - Adolescent: Accumulate a week of play time
+  - Acclimating: Accumulate a month of play time
 
 *web client*
 - fixed text extending past edge of notification bubbles

--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -11,6 +11,7 @@ Changelog
   - Adolescent: Accumulate a week of play time
   - Acclimating: Accumulate a month of play time
   - Sturdy Foundation: Accumulate 6 months of play time
+  - Devout: Accumulate a year of play time
 
 *web client*
 - fixed text extending past edge of notification bubbles

--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -6,6 +6,8 @@ Changelog
 
 *world*
 - renamed chef Patrick to Preston
+- new achievements:
+  - Cutting Teeth: Accumulate 24 hours of play time
 
 *web client*
 - fixed text extending past edge of notification bubbles

--- a/src/games/stendhal/server/core/rp/achievement/factory/AbstractAchievementFactory.java
+++ b/src/games/stendhal/server/core/rp/achievement/factory/AbstractAchievementFactory.java
@@ -62,6 +62,7 @@ public abstract class AbstractAchievementFactory {
 		List<AbstractAchievementFactory> list = new LinkedList<AbstractAchievementFactory>();
 		//add new created factories here
 		list.add(new AdosItemQuestAchievementsFactory());
+		list.add(new AgeAchievementFactory());
 		list.add(new DeathmatchAchievementFactory());
 		list.add(new ExperienceAchievementFactory());
 		list.add(new FightingAchievementFactory());

--- a/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
+++ b/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *                    Copyright © 2024 - Faiumoni e. V.                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+package games.stendhal.server.core.rp.achievement.factory;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import games.stendhal.common.MathHelper;
+import games.stendhal.server.core.rp.achievement.Achievement;
+import games.stendhal.server.core.rp.achievement.Category;
+import games.stendhal.server.entity.npc.condition.AgeGreaterThanCondition;
+
+
+public class AgeAchievementFactory extends AbstractAchievementFactory {
+
+	@Override
+	protected Category getCategory() {
+		return Category.AGE;
+	}
+
+	@Override
+	public Collection<Achievement> createAchievements() {
+		final LinkedList<Achievement> achievements = new LinkedList<Achievement>();
+
+		achievements.add(createAchievement(
+			"age.hours.00024", "Cutting Teeth",
+			"Accumulate 24 hours of play time",
+			Achievement.EASY_BASE_SCORE, true,
+			new AgeGreaterThanCondition(MathHelper.MINUTES_IN_ONE_DAY - 1)));
+
+		return achievements;
+	}
+}

--- a/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
+++ b/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
@@ -43,6 +43,13 @@ public class AgeAchievementFactory extends AbstractAchievementFactory {
 			Achievement.EASY_BASE_SCORE, true,
 			new AgeGreaterThanCondition(MathHelper.MINUTES_IN_ONE_WEEK - 1)));
 
+		// 31 days
+		achievements.add(createAchievement(
+			"age.hours.00744", "Acclimating",
+			"Accumulate a month of play time",
+			Achievement.MEDIUM_BASE_SCORE, true,
+			new AgeGreaterThanCondition((MathHelper.MINUTES_IN_ONE_DAY * 31) - 1)));
+
 		return achievements;
 	}
 }

--- a/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
+++ b/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
@@ -50,6 +50,13 @@ public class AgeAchievementFactory extends AbstractAchievementFactory {
 			Achievement.MEDIUM_BASE_SCORE, true,
 			new AgeGreaterThanCondition((MathHelper.MINUTES_IN_ONE_DAY * 31) - 1)));
 
+		// 182 days
+		achievements.add(createAchievement(
+			"age.hours.04368", "Sturdy Foundation",
+			"Accumulate 6 months of play time",
+			Achievement.HARD_BASE_SCORE, true,
+			new AgeGreaterThanCondition((MathHelper.MINUTES_IN_ONE_DAY * 182) - 1)));
+
 		return achievements;
 	}
 }

--- a/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
+++ b/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
@@ -37,6 +37,12 @@ public class AgeAchievementFactory extends AbstractAchievementFactory {
 			Achievement.EASY_BASE_SCORE, true,
 			new AgeGreaterThanCondition(MathHelper.MINUTES_IN_ONE_DAY - 1)));
 
+		achievements.add(createAchievement(
+			"age.hours.00168", "Adolescent",
+			"Accumulate a week of play time",
+			Achievement.EASY_BASE_SCORE, true,
+			new AgeGreaterThanCondition(MathHelper.MINUTES_IN_ONE_WEEK - 1)));
+
 		return achievements;
 	}
 }

--- a/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
+++ b/src/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactory.java
@@ -57,6 +57,12 @@ public class AgeAchievementFactory extends AbstractAchievementFactory {
 			Achievement.HARD_BASE_SCORE, true,
 			new AgeGreaterThanCondition((MathHelper.MINUTES_IN_ONE_DAY * 182) - 1)));
 
+		achievements.add(createAchievement(
+			"age.hours.08760", "Devout",
+			"Accumulate a year of play time",
+			Achievement.EXTREME_BASE_SCORE, true,
+			new AgeGreaterThanCondition((MathHelper.MINUTES_IN_ONE_DAY * 365) - 1)));
+
 		return achievements;
 	}
 }

--- a/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
+++ b/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
@@ -105,4 +105,9 @@ public class AgeAchievementFactoryTest extends AchievementTestHelper {
 	public void testAdolescent() {
 		testAchievement(168, Achievement.EASY_BASE_SCORE);
 	}
+
+	@Test
+	public void testAcclimating() {
+		testAchievement(744, Achievement.MEDIUM_BASE_SCORE);
+	}
 }

--- a/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
+++ b/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
@@ -115,4 +115,9 @@ public class AgeAchievementFactoryTest extends AchievementTestHelper {
 	public void testSturdyFoundation() {
 		testAchievement(4368, Achievement.HARD_BASE_SCORE);
 	}
+
+	@Test
+	public void testDevout() {
+		testAchievement(8760, Achievement.EXTREME_BASE_SCORE);
+	}
 }

--- a/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
+++ b/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
@@ -1,0 +1,103 @@
+/***************************************************************************
+ *                    Copyright © 2024 - Faiumoni e. V.                    *
+ ***************************************************************************
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+package games.stendhal.server.core.rp.achievement.factory;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import games.stendhal.common.MathHelper;
+import games.stendhal.server.core.rp.achievement.Achievement;
+import games.stendhal.server.entity.player.Player;
+import utilities.AchievementTestHelper;
+
+
+public class AgeAchievementFactoryTest extends AchievementTestHelper {
+
+	private Player player;
+
+
+	@Before
+	public void setUp() {
+		player = createPlayer(AgeAchievementFactoryTest.class.getSimpleName() + "Player");
+		assertThat(player, notNullValue());
+		init(player);
+	}
+
+	/**
+	 * Simulates player aging logic for a turn.
+	 *
+	 * The documentation suggests that `Player.getAge` represents the player's age in minutes. But
+	 * `MockStendhalRPRuleProcessor.beginTurn` increments this value every turn making the
+	 * representation actually age in turns. So we need to create a simulation that ages the player
+	 * 1 minute for every 200 turns.
+	 */
+	private void simulateLogic(final int currentTurn) {
+		if ((currentTurn + 1) % MathHelper.TURNS_IN_ONE_MINUTE == 0) {
+			// age player 1 minute
+			player.setAge(player.getAge() + 1);
+		}
+	}
+
+	/**
+	 * Ages player and checks achievement status.
+	 *
+	 * @param reqHours
+	 *   Age of player in hours required for achievement.
+	 * @param score
+	 *   Achievement score value.
+	 */
+	private void testAchievement(final int reqHours, final int score) {
+		final String id = "age.hours." + String.format("%05d", reqHours);
+		final Achievement ac = getById(id);
+		assertThat(ac, notNullValue());
+
+		System.out.println("testing age achievement: " + ac.getTitle() + " (" + reqHours + " hours)");
+		assertThat(ac.isActive(), is(true));
+		assertThat(ac.getBaseScore(), is(score));
+
+		assertThat(player.getAge(), is(0));
+		final int reqMinutes = reqHours * MathHelper.MINUTES_IN_ONE_HOUR;
+		final int reqTurns = reqMinutes * MathHelper.TURNS_IN_ONE_MINUTE;
+		// set age to 1 hour before target to expedite test
+		final int startMinutes = reqMinutes - MathHelper.MINUTES_IN_ONE_HOUR;
+		final int startTurns = startMinutes * MathHelper.TURNS_IN_ONE_MINUTE;
+		player.setAge(startMinutes);
+		assertThat(player.getAge(), is(startMinutes));
+		assertThat(player.getAge(), greaterThan(-1));
+
+		assertThat(achievementReached(player, id), is(false));
+
+		int currentTurn;
+		for (currentTurn = startTurns; currentTurn < reqTurns; currentTurn++) {
+			assertThat(achievementReached(player, id), is(false));
+			// simulate turn
+			simulateLogic(currentTurn);
+		}
+
+		final int totalMinutes = player.getAge();
+		final int totalHours = totalMinutes / MathHelper.MINUTES_IN_ONE_HOUR;
+		assertThat(currentTurn, is(reqTurns));
+		assertThat(totalMinutes, is(reqMinutes));
+		assertThat(totalHours, is(reqHours));
+		assertThat(achievementReached(player, id), is(true));
+	}
+
+	@Test
+	public void testCuttingTeeth() {
+		testAchievement(24, Achievement.EASY_BASE_SCORE);
+	}
+}

--- a/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
+++ b/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
@@ -110,4 +110,9 @@ public class AgeAchievementFactoryTest extends AchievementTestHelper {
 	public void testAcclimating() {
 		testAchievement(744, Achievement.MEDIUM_BASE_SCORE);
 	}
+
+	@Test
+	public void testSturdyFoundation() {
+		testAchievement(4368, Achievement.HARD_BASE_SCORE);
+	}
 }

--- a/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
+++ b/tests/games/stendhal/server/core/rp/achievement/factory/AgeAchievementFactoryTest.java
@@ -100,4 +100,9 @@ public class AgeAchievementFactoryTest extends AchievementTestHelper {
 	public void testCuttingTeeth() {
 		testAchievement(24, Achievement.EASY_BASE_SCORE);
 	}
+
+	@Test
+	public void testAdolescent() {
+		testAchievement(168, Achievement.EASY_BASE_SCORE);
+	}
 }

--- a/tests/utilities/AchievementTestHelper.java
+++ b/tests/utilities/AchievementTestHelper.java
@@ -1,5 +1,5 @@
 /***************************************************************************
- *                    Copyright © 2020-2023 - Arianne                      *
+ *                    Copyright © 2020-2024 - Arianne                      *
  ***************************************************************************
  ***************************************************************************
  *                                                                         *
@@ -67,18 +67,34 @@ public abstract class AchievementTestHelper extends PlayerTestHelper {
 	}
 
 	/**
+	 * Retrieves an achievement.
+	 *
+	 * @param id
+	 *   Achievement string identifier.
+	 * @return
+	 *   `games.stendhal.server.core.rp.achievement.Achievement` instance or `null`.
+	 */
+	public static Achievement getById(final String id) {
+		for (final Achievement ac: an.getAchievements()) {
+			if (id.equals(ac.getIdentifier())) {
+				return ac;
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Checks if an achievement is enabled.
 	 *
 	 * @param id
-	 *     Achievement string identifier.
+	 *   Achievement string identifier.
 	 * @return
-	 *     <code>true</code> if achievement is loaded & enabled.
+	 *   `true` if achievement is loaded & enabled.
 	 */
 	public static boolean achievementEnabled(final String id) {
-		for (final Achievement ac: an.getAchievements()) {
-			if (id.equals(ac.getIdentifier())) {
-				return ac.isActive();
-			}
+		final Achievement ac = AchievementTestHelper.getById(id);
+		if (ac != null) {
+			return ac.isActive();
 		}
 		return false;
 	}


### PR DESCRIPTION
Age related achievements as [suggested on the wiki](https://stendhalgame.org/wiki/Stendhal_Achievement_Ideas#Age).

- Cutting Teeth
    - _Accumulate 24 hours of play time_
    - ___difficulty:__ easy_
- Adolescent
    - Accumulate a week of play time
    - ___difficulty:__ easy_
- Acclimating
    - Accumulate a month of play time
    - ___difficulty:__ medium_
- Sturdy Foundation
    - Accumulate 6 months of play time
    - ___difficulty:__ hard_
- Devout
    - Accumulate a year of play time
    - ___difficulty:__ extreme_

There has been some valid discussion on the idea that these achievements will promote idling. My feeling is that idling (staying online without doing anything) is not a serious problem, especially in regards to Hall of Fame, as older age affects best player status negatively. I am strongly in favor of more high scoring & difficult achievements as I believe it makes the Hall of Fame Best Player category more accurate. I'm open to discussion on the subject, especially if there are other potential negative affects that I am not aware of.